### PR TITLE
Cache parents and children

### DIFF
--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/DefenseGenerator.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/DefenseGenerator.java
@@ -182,12 +182,10 @@ public class DefenseGenerator extends JavaGenerator {
 
   private void createSetField(TypeSpec.Builder parentBuilder, String name) {
     ClassName set = ClassName.get("java.util", "Set");
-    ClassName hashSet = ClassName.get("java.util", "HashSet");
     ClassName attackStep = ClassName.get("com.foreseeti.simulator", "AttackStep");
     TypeName type = ParameterizedTypeName.get(set, attackStep);
     FieldSpec.Builder builder = FieldSpec.builder(type, name);
     builder.addModifiers(Modifier.PRIVATE);
-    builder.initializer("new $T<>()", hashSet);
     parentBuilder.addField(builder.build());
   }
 }

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/DefenseGenerator.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/DefenseGenerator.java
@@ -17,7 +17,10 @@ package org.mal_lang.compiler.lib.securicad;
 
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import javax.lang.model.element.Modifier;
 import org.mal_lang.compiler.lib.JavaGenerator;
@@ -163,13 +166,28 @@ public class DefenseGenerator extends JavaGenerator {
     builder.addMethod(method.build());
 
     if (!attackStep.getReaches().isEmpty()) {
-      exprGen.createGetAttackStepChildren(builder, attackStep);
+      String name = String.format("_cacheChildren%s", ucFirst(attackStep.getName()));
+      createSetField(builder, name);
+      exprGen.createGetAttackStepChildren(builder, attackStep, name);
     }
 
     if (!attackStep.getParentSteps().isEmpty()) {
-      exprGen.createSetExpectedParents(builder, attackStep);
+      String name = String.format("_cacheParent%s", ucFirst(attackStep.getName()));
+      createSetField(builder, name);
+      exprGen.createSetExpectedParents(builder, attackStep, name);
     }
 
     parentBuilder.addType(builder.build());
+  }
+
+  private void createSetField(TypeSpec.Builder parentBuilder, String name) {
+    ClassName set = ClassName.get("java.util", "Set");
+    ClassName hashSet = ClassName.get("java.util", "HashSet");
+    ClassName attackStep = ClassName.get("com.foreseeti.simulator", "AttackStep");
+    TypeName type = ParameterizedTypeName.get(set, attackStep);
+    FieldSpec.Builder builder = FieldSpec.builder(type, name);
+    builder.addModifiers(Modifier.PRIVATE);
+    builder.initializer("new $T<>()", hashSet);
+    parentBuilder.addField(builder.build());
   }
 }

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/ExpressionGenerator.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/ExpressionGenerator.java
@@ -73,7 +73,7 @@ public class ExpressionGenerator extends JavaGenerator {
     }
     builder.endControlFlow();
 
-    builder.addStatement("return $L", cacheName);
+    builder.addStatement("return new $T<>($L)", HashSet.class, cacheName);
     parentBuilder.addMethod(builder.build());
   }
 

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/ExpressionGenerator.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/ExpressionGenerator.java
@@ -48,7 +48,7 @@ public class ExpressionGenerator extends JavaGenerator {
   }
 
   protected void createGetAttackStepChildren(
-      TypeSpec.Builder parentBuilder, AttackStep attackStep) {
+      TypeSpec.Builder parentBuilder, AttackStep attackStep, String cacheName) {
     Name.reset();
     MethodSpec.Builder builder = MethodSpec.methodBuilder("getAttackStepChildren");
     builder.addAnnotation(Override.class);
@@ -58,37 +58,50 @@ public class ExpressionGenerator extends JavaGenerator {
     ClassName hashSet = ClassName.get(HashSet.class);
     TypeName asSet = ParameterizedTypeName.get(set, as);
     builder.returns(asSet);
-    String setName = Name.get();
+
+    builder.beginControlFlow("if ($N == null)", cacheName);
     if (attackStep.inheritsReaches()) {
-      builder.addStatement(
-          "$T $L = new $T<>(super.getAttackStepChildren())", asSet, setName, hashSet);
+      builder.addStatement("$L = new $T<>(super.getAttackStepChildren())", cacheName, hashSet);
     } else {
-      builder.addStatement("$T $L = new $T<>()", asSet, setName, hashSet);
+      builder.addStatement("$L = new $T<>()", cacheName, hashSet);
     }
     for (StepExpr expr : attackStep.getReaches()) {
       AutoFlow af = new AutoFlow();
       AutoFlow end = generate(af, expr, attackStep.getAsset(), "(null)");
-      end.addStatement("$L.add($L)", setName, end.prefix);
+      end.addStatement("$L.add($L)", cacheName, end.prefix);
       af.build(builder);
     }
-    builder.addStatement("return $L", setName);
+    builder.endControlFlow();
+
+    builder.addStatement("return $L", cacheName);
     parentBuilder.addMethod(builder.build());
   }
 
-  protected void createSetExpectedParents(TypeSpec.Builder parentBuilder, AttackStep attackStep) {
+  protected void createSetExpectedParents(
+      TypeSpec.Builder parentBuilder, AttackStep attackStep, String cacheName) {
     Name.reset();
     MethodSpec.Builder builder = MethodSpec.methodBuilder("setExpectedParents");
     builder.addAnnotation(Override.class);
     builder.addModifiers(Modifier.PUBLIC);
     ClassName concreteSample = ClassName.get("com.foreseeti.simulator", "ConcreteSample");
     builder.addParameter(concreteSample, "sample");
+
     builder.addStatement("super.setExpectedParents(sample)");
+    builder.beginControlFlow("if ($N == null)", cacheName);
+    builder.addStatement("$N = new $T<>()", cacheName, HashSet.class);
     for (StepExpr expr : attackStep.getParentSteps()) {
       AutoFlow af = new AutoFlow();
       AutoFlow end = generate(af, expr, attackStep.getAsset(), "(sample)");
-      end.addStatement("sample.addExpectedParent(this, $N)", end.prefix);
+      end.addStatement("$N.add($N)", cacheName, end.prefix);
       af.build(builder);
     }
+    builder.endControlFlow();
+
+    ClassName as = ClassName.get("com.foreseeti.simulator", "AttackStep");
+    builder.beginControlFlow("for($T attackStep : $N)", as, cacheName);
+    builder.addStatement("sample.addExpectedParent(this, attackStep)");
+    builder.endControlFlow();
+
     parentBuilder.addMethod(builder.build());
   }
 


### PR DESCRIPTION
Caching parents and children yields a ~85% improvement in simulation time for large samples.