### PR TITLE
Changed meta info labels

### DIFF
--- a/grammar
+++ b/grammar
@@ -1,13 +1,14 @@
 ; rules
 <mal>           ::= (<category> | <associations> | <include> | <define>)* EOF
 <define>        ::= HASH ID COLON STRING
-<meta>          ::= ID INFO COLON STRING
+<meta1>         ::= ID <meta2>
+<meta2>         ::= INFO COLON STRING
 <include>       ::= INCLUDE STRING
 <number>        ::= INT | FLOAT
 
-<category>      ::= CATEGORY ID <meta>* LCURLY <asset>* RCURLY
-<asset>         ::= ABSTRACT? ASSET ID (EXTENDS ID)? <meta>* LCURLY (<attackstep> | <variable>)* RCURLY
-<attackstep>    ::= <astype> ID <tag>* <cia>? <ttc>? <meta>* <existence>? <reaches>?
+<category>      ::= CATEGORY ID <meta1>* LCURLY <asset>* RCURLY
+<asset>         ::= ABSTRACT? ASSET ID (EXTENDS ID)? <meta1>* LCURLY (<attackstep> | <variable>)* RCURLY
+<attackstep>    ::= <astype> ID <tag>* <cia>? <ttc>? <meta1>* <existence>? <reaches>?
 <astype>        ::= ALL | ANY | HASH | EXIST | NOTEXIST
 <tag>           ::= AT ID
 <cia>           ::= LCURLY <cia-list>? RCURLY
@@ -28,8 +29,9 @@
 <subtype>       ::= <prim> <type>?
 <prim>          ::= ID | LPAREN <expr> RPAREN
 
-<associations>  ::= ASSOCIATIONS LCURLY <association>* RCURLY
-<association>   ::= ID <type> <mult> LARROW ID RARROW <mult> <type> ID <meta>*
+<associations>  ::= ASSOCIATIONS LCURLY <associations1>? RCURLY
+<associations1> ::= ID <association> (ID (<meta2> | <association>))*
+<association>   ::= <type> <mult> LARROW ID RARROW <mult> <type> ID
 <mult>          ::= <mult-unit> (RANGE <mult-unit>)?
 <mult-unit>     ::= INT | STAR
 <type>          ::= LBRACKET ID LBRACKET

--- a/grammar
+++ b/grammar
@@ -1,8 +1,7 @@
 ; rules
 <mal>           ::= (<category> | <associations> | <include> | <define>)* EOF
 <define>        ::= HASH ID COLON STRING
-<meta>          ::= <meta-type> COLON STRING
-<meta-type>     ::= INFO | ASSUMPTIONS | RATIONALE
+<meta>          ::= ID INFO COLON STRING
 <include>       ::= INCLUDE STRING
 <number>        ::= INT | FLOAT
 
@@ -39,8 +38,6 @@
 ; keywords
 INCLUDE         ::= "include"
 INFO            ::= "info"
-ASSUMPTIONS     ::= "assumptions"
-RATIONALE       ::= "rationale"
 CATEGORY        ::= "category"
 ABSTRACT        ::= "abstract"
 ASSET           ::= "asset"

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/AST.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/AST.java
@@ -114,28 +114,11 @@ public class AST {
     }
   }
 
-  public enum MetaType {
-    INFO("'info'"),
-    ASSUMPTIONS("'assumptions'"),
-    RATIONALE("'rationale'");
-
-    String string;
-
-    private MetaType(String string) {
-      this.string = string;
-    }
-
-    @Override
-    public String toString() {
-      return string;
-    }
-  }
-
   public static class Meta extends Position {
-    public final MetaType type;
+    public final ID type;
     public final String string;
 
-    public Meta(Position pos, MetaType type, String string) {
+    public Meta(Position pos, ID type, String string) {
       super(pos);
       this.type = type;
       this.string = string;
@@ -143,7 +126,7 @@ public class AST {
 
     @Override
     public String toString() {
-      return String.format("Meta(%s, %s, \"%s\")", posString(), type.name(), string);
+      return String.format("Meta(%s, %s, \"%s\")", posString(), type.toString(), string);
     }
 
     public static String listToString(List<Meta> meta, int spaces) {

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/Analyzer.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/Analyzer.java
@@ -219,15 +219,27 @@ public class Analyzer {
   }
 
   private void checkMeta(List<AST.Meta> lst) {
-    Map<AST.MetaType, AST.Meta> metas = new HashMap<>();
+    Map<String, AST.Meta> metas = new HashMap<>();
     for (AST.Meta meta : lst) {
-      if (!metas.containsKey(meta.type)) {
-        metas.put(meta.type, meta);
+      if (!metas.containsKey(meta.type.id)) {
+        switch (meta.type.id) {
+          case "user":
+          case "developer":
+          case "modeler":
+            metas.put(meta.type.id, meta);
+            break;
+          default:
+            error(
+                meta,
+                String.format(
+                    "Metadata type '%s' must be 'user', 'developer' or 'modeler'", meta.type.id));
+        }
       } else {
-        AST.Meta prevDef = metas.get(meta.type);
+        AST.Meta prevDef = metas.get(meta.type.id);
         error(
             meta,
-            String.format("Metadata %s previously defined at %s", meta.type, prevDef.posString()));
+            String.format(
+                "Metadata %s previously defined at %s", meta.type.id, prevDef.posString()));
       }
     }
   }

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/Lang.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/Lang.java
@@ -78,47 +78,14 @@ public class Lang {
     return List.copyOf(this.links);
   }
 
-  public static class Meta {
-    private String info;
-    private String assumptions;
-    private String rationale;
-
-    public String getInfo() {
-      return this.info;
-    }
-
-    public Meta setInfo(String info) {
-      this.info = info;
-      return this;
-    }
-
-    public String getAssumptions() {
-      return this.assumptions;
-    }
-
-    public Meta setAssumptions(String assumptions) {
-      this.assumptions = assumptions;
-      return this;
-    }
-
-    public String getRationale() {
-      return this.rationale;
-    }
-
-    public Meta setRationale(String rationale) {
-      this.rationale = rationale;
-      return this;
-    }
-  }
-
   public static class Category {
     private String name;
-    private Meta meta;
+    private Map<String, String> meta;
     private Map<String, Asset> assets;
 
     public Category(String name) {
       this.name = name;
-      this.meta = new Meta();
+      this.meta = new LinkedHashMap<>();
       this.assets = new LinkedHashMap<>();
     }
 
@@ -126,7 +93,7 @@ public class Lang {
       return this.name;
     }
 
-    public Meta getMeta() {
+    public Map<String, String> getMeta() {
       return this.meta;
     }
 
@@ -151,7 +118,7 @@ public class Lang {
     private String name;
     private boolean isAbstract;
     private Category category;
-    private Meta meta;
+    private Map<String, String> meta;
     private Asset superAsset;
     private Map<String, Field> fields;
     private Map<String, AttackStep> attackSteps;
@@ -160,7 +127,7 @@ public class Lang {
       this.name = name;
       this.isAbstract = isAbstract;
       this.category = category;
-      this.meta = new Meta();
+      this.meta = new LinkedHashMap<>();
       this.fields = new LinkedHashMap<>();
       this.attackSteps = new LinkedHashMap<>();
     }
@@ -177,7 +144,7 @@ public class Lang {
       return this.category;
     }
 
-    public Meta getMeta() {
+    public Map<String, String> getMeta() {
       return this.meta;
     }
 
@@ -240,20 +207,20 @@ public class Lang {
 
   public static class Link {
     private String name;
-    private Meta meta;
+    private Map<String, String> meta;
     private Field leftField;
     private Field rightField;
 
     public Link(String name) {
       this.name = name;
-      this.meta = new Meta();
+      this.meta = new LinkedHashMap<>();
     }
 
     public String getName() {
       return this.name;
     }
 
-    public Meta getMeta() {
+    public Map<String, String> getMeta() {
       return this.meta;
     }
 
@@ -340,7 +307,7 @@ public class Lang {
     private boolean inheritsReaches;
     private List<String> tags;
     private CIA cia;
-    private Meta meta;
+    private Map<String, String> meta;
     private TTCExpr ttc;
     private List<StepExpr> requires;
     private List<StepExpr> reaches;
@@ -354,7 +321,7 @@ public class Lang {
       this.inheritsReaches = inheritsReaches;
       this.tags = new ArrayList<>();
       this.cia = cia;
-      this.meta = new Meta();
+      this.meta = new LinkedHashMap<>();
       this.requires = new ArrayList<>();
       this.reaches = new ArrayList<>();
       this.parentSteps = new ArrayList<>();
@@ -376,7 +343,7 @@ public class Lang {
       return this.inheritsReaches;
     }
 
-    public Meta getMeta() {
+    public Map<String, String> getMeta() {
       return this.meta;
     }
 

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/LangConverter.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/LangConverter.java
@@ -196,23 +196,9 @@ public class LangConverter {
     return new Lang(langDefines, langCategories, langAssets, langLinks);
   }
 
-  private void _convertMetaList(Lang.Meta meta, List<AST.Meta> astMetaList) {
+  private void _convertMetaList(Map<String, String> meta, List<AST.Meta> astMetaList) {
     for (var astMeta : astMetaList) {
-      _convertMeta(meta, astMeta);
-    }
-  }
-
-  private void _convertMeta(Lang.Meta meta, AST.Meta astMeta) {
-    switch (astMeta.type) {
-      case INFO:
-        meta.setInfo(astMeta.string);
-        break;
-      case ASSUMPTIONS:
-        meta.setAssumptions(astMeta.string);
-        break;
-      case RATIONALE:
-        meta.setRationale(astMeta.string);
-        break;
+      meta.put(astMeta.type.id, astMeta.string);
     }
   }
 

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/Lexer.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/Lexer.java
@@ -43,8 +43,6 @@ public class Lexer {
     keywords = new HashMap<>();
     keywords.put("include", TokenType.INCLUDE);
     keywords.put("info", TokenType.INFO);
-    keywords.put("assumptions", TokenType.ASSUMPTIONS);
-    keywords.put("rationale", TokenType.RATIONALE);
     keywords.put("category", TokenType.CATEGORY);
     keywords.put("abstract", TokenType.ABSTRACT);
     keywords.put("asset", TokenType.ASSET);

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/Parser.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/Parser.java
@@ -171,11 +171,13 @@ public class Parser {
     return new AST.Define(firstToken, key, value);
   }
 
+  // <meta1> ::= ID <meta2>
   private AST.Meta _parseMeta1() throws CompilerException {
     var type = _parseID();
     return _parseMeta2(type);
   }
 
+  // <meta2> ::= INFO COLON STRING
   private AST.Meta _parseMeta2(AST.ID type) throws CompilerException {
     _expect(TokenType.INFO);
     _expect(TokenType.COLON);
@@ -259,8 +261,8 @@ public class Parser {
     return new AST.Category(firstToken, name, meta, assets);
   }
 
-  // <asset> ::= ABSTRACT? ASSET ID (EXTENDS ID)? <meta1>* LCURLY (<attackstep> | <variable>)*
-  // RCURLY
+  // <asset> ::=
+  //           ABSTRACT? ASSET ID (EXTENDS ID)? <meta1>* LCURLY (<attackstep> | <variable>)* RCURLY
   private AST.Asset _parseAsset() throws CompilerException {
     var firstToken = tok;
 

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/TokenType.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/TokenType.java
@@ -20,8 +20,6 @@ public enum TokenType {
 
   INCLUDE("'include'"),
   INFO("'info'"),
-  ASSUMPTIONS("'assumptions'"),
-  RATIONALE("'rationale'"),
   CATEGORY("'category'"),
   ABSTRACT("'abstract'"),
   ASSET("'asset'"),

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/AssetGenerator.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/AssetGenerator.java
@@ -342,7 +342,7 @@ public class AssetGenerator extends JavaGenerator {
     builder.addAnnotation(Override.class);
     builder.addModifiers(Modifier.PUBLIC);
     builder.returns(String.class);
-    String info = asset.getMeta().getInfo();
+    String info = asset.getMeta().get("user");
     builder.addStatement("return $S", info != null ? info : "");
     parentBuilder.addMethod(builder.build());
   }

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/allfeatures/TestAllFeatures.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/allfeatures/TestAllFeatures.java
@@ -36,11 +36,13 @@ import static org.mal_lang.compiler.test.lib.AssertToken.assertTokens;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mal_lang.compiler.lib.AST;
+import org.mal_lang.compiler.lib.AST.ID;
 import org.mal_lang.compiler.lib.Distributions;
 import org.mal_lang.compiler.lib.Lang;
 import org.mal_lang.compiler.lib.Position;
@@ -81,15 +83,18 @@ public class TestAllFeatures extends MalTest {
     Token[] tokens = {
       new Token(TokenType.CATEGORY, CORE_MAL, 1, 1),
       new Token(TokenType.ID, CORE_MAL, 1, 10, "C1"),
-      new Token(TokenType.INFO, CORE_MAL, 2, 3),
-      new Token(TokenType.COLON, CORE_MAL, 2, 7),
-      new Token(TokenType.STRING, CORE_MAL, 2, 9, "This is C1"),
-      new Token(TokenType.ASSUMPTIONS, CORE_MAL, 3, 3),
-      new Token(TokenType.COLON, CORE_MAL, 3, 14),
-      new Token(TokenType.STRING, CORE_MAL, 3, 16, "None for C1"),
-      new Token(TokenType.RATIONALE, CORE_MAL, 4, 3),
-      new Token(TokenType.COLON, CORE_MAL, 4, 12),
-      new Token(TokenType.STRING, CORE_MAL, 4, 14, "Reasoning for C1"),
+      new Token(TokenType.ID, CORE_MAL, 2, 3, "user"),
+      new Token(TokenType.INFO, CORE_MAL, 2, 8),
+      new Token(TokenType.COLON, CORE_MAL, 2, 12),
+      new Token(TokenType.STRING, CORE_MAL, 2, 14, "This is C1"),
+      new Token(TokenType.ID, CORE_MAL, 3, 3, "modeler"),
+      new Token(TokenType.INFO, CORE_MAL, 3, 11),
+      new Token(TokenType.COLON, CORE_MAL, 3, 15),
+      new Token(TokenType.STRING, CORE_MAL, 3, 17, "None for C1"),
+      new Token(TokenType.ID, CORE_MAL, 4, 3, "developer"),
+      new Token(TokenType.INFO, CORE_MAL, 4, 13),
+      new Token(TokenType.COLON, CORE_MAL, 4, 17),
+      new Token(TokenType.STRING, CORE_MAL, 4, 19, "Reasoning for C1"),
       new Token(TokenType.LCURLY, CORE_MAL, 5, 1),
       new Token(TokenType.RCURLY, CORE_MAL, 7, 1),
       new Token(TokenType.CATEGORY, CORE_MAL, 9, 1),
@@ -103,15 +108,18 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.LCURLY, CORE_MAL, 12, 17),
       new Token(TokenType.C, CORE_MAL, 12, 18),
       new Token(TokenType.RCURLY, CORE_MAL, 12, 19),
-      new Token(TokenType.INFO, CORE_MAL, 13, 7),
-      new Token(TokenType.COLON, CORE_MAL, 13, 11),
-      new Token(TokenType.STRING, CORE_MAL, 13, 13, "This is a1Attack1"),
-      new Token(TokenType.ASSUMPTIONS, CORE_MAL, 14, 7),
-      new Token(TokenType.COLON, CORE_MAL, 14, 18),
-      new Token(TokenType.STRING, CORE_MAL, 14, 20, "None for a1Attack1"),
-      new Token(TokenType.RATIONALE, CORE_MAL, 15, 7),
-      new Token(TokenType.COLON, CORE_MAL, 15, 16),
-      new Token(TokenType.STRING, CORE_MAL, 15, 18, "Reasoning for a1Attack1"),
+      new Token(TokenType.ID, CORE_MAL, 13, 7, "user"),
+      new Token(TokenType.INFO, CORE_MAL, 13, 12),
+      new Token(TokenType.COLON, CORE_MAL, 13, 16),
+      new Token(TokenType.STRING, CORE_MAL, 13, 18, "This is a1Attack1"),
+      new Token(TokenType.ID, CORE_MAL, 14, 7, "modeler"),
+      new Token(TokenType.INFO, CORE_MAL, 14, 15),
+      new Token(TokenType.COLON, CORE_MAL, 14, 19),
+      new Token(TokenType.STRING, CORE_MAL, 14, 21, "None for a1Attack1"),
+      new Token(TokenType.ID, CORE_MAL, 15, 7, "developer"),
+      new Token(TokenType.INFO, CORE_MAL, 15, 17),
+      new Token(TokenType.COLON, CORE_MAL, 15, 21),
+      new Token(TokenType.STRING, CORE_MAL, 15, 23, "Reasoning for a1Attack1"),
       new Token(TokenType.ALL, CORE_MAL, 17, 5),
       new Token(TokenType.ID, CORE_MAL, 17, 7, "a1Attack2"),
       new Token(TokenType.LCURLY, CORE_MAL, 17, 17),
@@ -121,9 +129,10 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.RCURLY, CORE_MAL, 17, 22),
       new Token(TokenType.LBRACKET, CORE_MAL, 17, 24),
       new Token(TokenType.RBRACKET, CORE_MAL, 17, 25),
-      new Token(TokenType.INFO, CORE_MAL, 18, 7),
-      new Token(TokenType.COLON, CORE_MAL, 18, 11),
-      new Token(TokenType.STRING, CORE_MAL, 18, 13, "This is a1Attack2"),
+      new Token(TokenType.ID, CORE_MAL, 18, 7, "user"),
+      new Token(TokenType.INFO, CORE_MAL, 18, 12),
+      new Token(TokenType.COLON, CORE_MAL, 18, 16),
+      new Token(TokenType.STRING, CORE_MAL, 18, 18, "This is a1Attack2"),
       new Token(TokenType.OVERRIDE, CORE_MAL, 19, 7),
       new Token(TokenType.ID, CORE_MAL, 19, 10, "a1Sub"),
       new Token(TokenType.LBRACKET, CORE_MAL, 19, 15),
@@ -140,9 +149,10 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.FLOAT, CORE_MAL, 20, 29, 0.5),
       new Token(TokenType.RPAREN, CORE_MAL, 20, 32),
       new Token(TokenType.RBRACKET, CORE_MAL, 20, 33),
-      new Token(TokenType.RATIONALE, CORE_MAL, 21, 7),
-      new Token(TokenType.COLON, CORE_MAL, 21, 16),
-      new Token(TokenType.STRING, CORE_MAL, 21, 18, "Reasoning for a1Defense"),
+      new Token(TokenType.ID, CORE_MAL, 21, 7, "developer"),
+      new Token(TokenType.INFO, CORE_MAL, 21, 17),
+      new Token(TokenType.COLON, CORE_MAL, 21, 21),
+      new Token(TokenType.STRING, CORE_MAL, 21, 23, "Reasoning for a1Defense"),
       new Token(TokenType.HASH, CORE_MAL, 23, 5),
       new Token(TokenType.ID, CORE_MAL, 23, 7, "a1Defense2"),
       new Token(TokenType.LBRACKET, CORE_MAL, 23, 18),
@@ -156,9 +166,10 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 26, 10, "a1Sub"),
       new Token(TokenType.EXIST, CORE_MAL, 28, 5),
       new Token(TokenType.ID, CORE_MAL, 28, 7, "a1Exist2"),
-      new Token(TokenType.ASSUMPTIONS, CORE_MAL, 29, 7),
-      new Token(TokenType.COLON, CORE_MAL, 29, 18),
-      new Token(TokenType.STRING, CORE_MAL, 29, 20, "None for a1Exist2"),
+      new Token(TokenType.ID, CORE_MAL, 29, 7, "modeler"),
+      new Token(TokenType.INFO, CORE_MAL, 29, 15),
+      new Token(TokenType.COLON, CORE_MAL, 29, 19),
+      new Token(TokenType.STRING, CORE_MAL, 29, 21, "None for a1Exist2"),
       new Token(TokenType.REQUIRE, CORE_MAL, 30, 7),
       new Token(TokenType.ID, CORE_MAL, 30, 10, "a7"),
       new Token(TokenType.COMMA, CORE_MAL, 30, 12),
@@ -265,9 +276,10 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 63, 18, "A3"),
       new Token(TokenType.EXTENDS, CORE_MAL, 63, 21),
       new Token(TokenType.ID, CORE_MAL, 63, 29, "A1"),
-      new Token(TokenType.INFO, CORE_MAL, 64, 5),
-      new Token(TokenType.COLON, CORE_MAL, 64, 9),
-      new Token(TokenType.STRING, CORE_MAL, 64, 11, "This is A3"),
+      new Token(TokenType.ID, CORE_MAL, 64, 5, "user"),
+      new Token(TokenType.INFO, CORE_MAL, 64, 10),
+      new Token(TokenType.COLON, CORE_MAL, 64, 14),
+      new Token(TokenType.STRING, CORE_MAL, 64, 16, "This is A3"),
       new Token(TokenType.LCURLY, CORE_MAL, 65, 3),
       new Token(TokenType.LET, CORE_MAL, 66, 5),
       new Token(TokenType.ID, CORE_MAL, 66, 9, "unused"),
@@ -316,22 +328,26 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.RCURLY, CORE_MAL, 78, 44),
       new Token(TokenType.CATEGORY, CORE_MAL, 80, 1),
       new Token(TokenType.ID, CORE_MAL, 80, 10, "C2"),
-      new Token(TokenType.ASSUMPTIONS, CORE_MAL, 81, 3),
-      new Token(TokenType.COLON, CORE_MAL, 81, 14),
-      new Token(TokenType.STRING, CORE_MAL, 81, 16, "None for C2"),
+      new Token(TokenType.ID, CORE_MAL, 81, 3, "modeler"),
+      new Token(TokenType.INFO, CORE_MAL, 81, 11),
+      new Token(TokenType.COLON, CORE_MAL, 81, 15),
+      new Token(TokenType.STRING, CORE_MAL, 81, 17, "None for C2"),
       new Token(TokenType.LCURLY, CORE_MAL, 82, 1),
       new Token(TokenType.ABSTRACT, CORE_MAL, 83, 3),
       new Token(TokenType.ASSET, CORE_MAL, 83, 12),
       new Token(TokenType.ID, CORE_MAL, 83, 18, "A4"),
-      new Token(TokenType.ASSUMPTIONS, CORE_MAL, 84, 5),
-      new Token(TokenType.COLON, CORE_MAL, 84, 16),
-      new Token(TokenType.STRING, CORE_MAL, 84, 18, "None for A4"),
-      new Token(TokenType.RATIONALE, CORE_MAL, 85, 5),
-      new Token(TokenType.COLON, CORE_MAL, 85, 14),
-      new Token(TokenType.STRING, CORE_MAL, 85, 16, "Reasoning for A4"),
-      new Token(TokenType.INFO, CORE_MAL, 86, 5),
-      new Token(TokenType.COLON, CORE_MAL, 86, 9),
-      new Token(TokenType.STRING, CORE_MAL, 86, 11, "This is A4"),
+      new Token(TokenType.ID, CORE_MAL, 84, 5, "modeler"),
+      new Token(TokenType.INFO, CORE_MAL, 84, 13),
+      new Token(TokenType.COLON, CORE_MAL, 84, 17),
+      new Token(TokenType.STRING, CORE_MAL, 84, 19, "None for A4"),
+      new Token(TokenType.ID, CORE_MAL, 85, 5, "developer"),
+      new Token(TokenType.INFO, CORE_MAL, 85, 15),
+      new Token(TokenType.COLON, CORE_MAL, 85, 19),
+      new Token(TokenType.STRING, CORE_MAL, 85, 21, "Reasoning for A4"),
+      new Token(TokenType.ID, CORE_MAL, 86, 5, "user"),
+      new Token(TokenType.INFO, CORE_MAL, 86, 10),
+      new Token(TokenType.COLON, CORE_MAL, 86, 14),
+      new Token(TokenType.STRING, CORE_MAL, 86, 16, "This is A4"),
       new Token(TokenType.LCURLY, CORE_MAL, 87, 3),
       new Token(TokenType.LET, CORE_MAL, 88, 5),
       new Token(TokenType.ID, CORE_MAL, 88, 9, "var"),
@@ -369,17 +385,19 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.RCURLY, CORE_MAL, 96, 1),
       new Token(TokenType.CATEGORY, CORE_MAL, 98, 1),
       new Token(TokenType.ID, CORE_MAL, 98, 10, "C2"),
-      new Token(TokenType.RATIONALE, CORE_MAL, 99, 3),
-      new Token(TokenType.COLON, CORE_MAL, 99, 12),
-      new Token(TokenType.STRING, CORE_MAL, 99, 14, "Reasoning for C2"),
+      new Token(TokenType.ID, CORE_MAL, 99, 3, "developer"),
+      new Token(TokenType.INFO, CORE_MAL, 99, 13),
+      new Token(TokenType.COLON, CORE_MAL, 99, 17),
+      new Token(TokenType.STRING, CORE_MAL, 99, 19, "Reasoning for C2"),
       new Token(TokenType.LCURLY, CORE_MAL, 100, 1),
       new Token(TokenType.ASSET, CORE_MAL, 101, 3),
       new Token(TokenType.ID, CORE_MAL, 101, 9, "A5"),
       new Token(TokenType.EXTENDS, CORE_MAL, 101, 12),
       new Token(TokenType.ID, CORE_MAL, 101, 20, "A4"),
-      new Token(TokenType.ASSUMPTIONS, CORE_MAL, 102, 5),
-      new Token(TokenType.COLON, CORE_MAL, 102, 16),
-      new Token(TokenType.STRING, CORE_MAL, 102, 18, "None for A5"),
+      new Token(TokenType.ID, CORE_MAL, 102, 5, "modeler"),
+      new Token(TokenType.INFO, CORE_MAL, 102, 13),
+      new Token(TokenType.COLON, CORE_MAL, 102, 17),
+      new Token(TokenType.STRING, CORE_MAL, 102, 19, "None for A5"),
       new Token(TokenType.LCURLY, CORE_MAL, 103, 3),
       new Token(TokenType.RCURLY, CORE_MAL, 103, 31),
       new Token(TokenType.ABSTRACT, CORE_MAL, 105, 3),
@@ -387,9 +405,10 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 105, 18, "A6"),
       new Token(TokenType.EXTENDS, CORE_MAL, 105, 21),
       new Token(TokenType.ID, CORE_MAL, 105, 29, "A4"),
-      new Token(TokenType.RATIONALE, CORE_MAL, 106, 5),
-      new Token(TokenType.COLON, CORE_MAL, 106, 14),
-      new Token(TokenType.STRING, CORE_MAL, 106, 16, "Reasoning for A6"),
+      new Token(TokenType.ID, CORE_MAL, 106, 5, "developer"),
+      new Token(TokenType.INFO, CORE_MAL, 106, 15),
+      new Token(TokenType.COLON, CORE_MAL, 106, 19),
+      new Token(TokenType.STRING, CORE_MAL, 106, 21, "Reasoning for A6"),
       new Token(TokenType.LCURLY, CORE_MAL, 107, 3),
       new Token(TokenType.RCURLY, CORE_MAL, 109, 3),
       new Token(TokenType.RCURLY, CORE_MAL, 110, 1),
@@ -458,17 +477,11 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.LCURLY, CORE_MAL, 133, 12),
       new Token(TokenType.RCURLY, CORE_MAL, 136, 3),
       new Token(TokenType.RCURLY, CORE_MAL, 137, 1),
-
-      // 139: associations { /* No associations here */ }
       new Token(TokenType.ASSOCIATIONS, CORE_MAL, 139, 1),
       new Token(TokenType.LCURLY, CORE_MAL, 139, 14),
       new Token(TokenType.RCURLY, CORE_MAL, 139, 43),
-
-      // 141: associations {
       new Token(TokenType.ASSOCIATIONS, CORE_MAL, 141, 1),
       new Token(TokenType.LCURLY, CORE_MAL, 141, 14),
-
-      // 143:   A1 [a1]      1    <-- L1 --> 1..* [a4]    A4
       new Token(TokenType.ID, CORE_MAL, 143, 3, "A1"),
       new Token(TokenType.LBRACKET, CORE_MAL, 143, 6),
       new Token(TokenType.ID, CORE_MAL, 143, 7, "a1"),
@@ -484,8 +497,6 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 143, 38, "a4"),
       new Token(TokenType.RBRACKET, CORE_MAL, 143, 40),
       new Token(TokenType.ID, CORE_MAL, 143, 45, "A4"),
-
-      // 144:   A5 [a5]      1..1 <-- L2 --> 0..* [a6]    A6
       new Token(TokenType.ID, CORE_MAL, 144, 3, "A5"),
       new Token(TokenType.LBRACKET, CORE_MAL, 144, 6),
       new Token(TokenType.ID, CORE_MAL, 144, 7, "a5"),
@@ -503,15 +514,9 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 144, 38, "a6"),
       new Token(TokenType.RBRACKET, CORE_MAL, 144, 40),
       new Token(TokenType.ID, CORE_MAL, 144, 45, "A6"),
-
-      // 145: }
       new Token(TokenType.RCURLY, CORE_MAL, 145, 1),
-
-      // 147: associations {
       new Token(TokenType.ASSOCIATIONS, CORE_MAL, 147, 1),
       new Token(TokenType.LCURLY, CORE_MAL, 147, 14),
-
-      // 149:   A1 [a1Super] 0..1 <-- L3 --> *    [a1Sub]   A1
       new Token(TokenType.ID, CORE_MAL, 149, 3, "A1"),
       new Token(TokenType.LBRACKET, CORE_MAL, 149, 6),
       new Token(TokenType.ID, CORE_MAL, 149, 7, "a1Super"),
@@ -527,8 +532,6 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 149, 38, "a1Sub"),
       new Token(TokenType.RBRACKET, CORE_MAL, 149, 43),
       new Token(TokenType.ID, CORE_MAL, 149, 47, "A1"),
-
-      // 150:   A3 [a3]      *    <-- L3 --> *    [a6]      A6
       new Token(TokenType.ID, CORE_MAL, 150, 3, "A3"),
       new Token(TokenType.LBRACKET, CORE_MAL, 150, 6),
       new Token(TokenType.ID, CORE_MAL, 150, 7, "a3"),
@@ -542,8 +545,6 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 150, 38, "a6"),
       new Token(TokenType.RBRACKET, CORE_MAL, 150, 40),
       new Token(TokenType.ID, CORE_MAL, 150, 47, "A6"),
-
-      // 151:   A7 [a7]      0..1 <-- L3 --> 1    [a1]      A1
       new Token(TokenType.ID, CORE_MAL, 151, 3, "A7"),
       new Token(TokenType.LBRACKET, CORE_MAL, 151, 6),
       new Token(TokenType.ID, CORE_MAL, 151, 7, "a7"),
@@ -559,8 +560,6 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 151, 38, "a1"),
       new Token(TokenType.RBRACKET, CORE_MAL, 151, 40),
       new Token(TokenType.ID, CORE_MAL, 151, 47, "A1"),
-
-      // 152:   A8 [a8]      *    <-- L4 --> *    [a1]      A1
       new Token(TokenType.ID, CORE_MAL, 152, 3, "A8"),
       new Token(TokenType.LBRACKET, CORE_MAL, 152, 6),
       new Token(TokenType.ID, CORE_MAL, 152, 7, "a8"),
@@ -574,8 +573,6 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 152, 38, "a1"),
       new Token(TokenType.RBRACKET, CORE_MAL, 152, 40),
       new Token(TokenType.ID, CORE_MAL, 152, 47, "A1"),
-
-      // 153:   A8 [a8]      *    <-- L4 --> *    [a4]      A4
       new Token(TokenType.ID, CORE_MAL, 153, 3, "A8"),
       new Token(TokenType.LBRACKET, CORE_MAL, 153, 6),
       new Token(TokenType.ID, CORE_MAL, 153, 7, "a8"),
@@ -589,8 +586,6 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 153, 38, "a4"),
       new Token(TokenType.RBRACKET, CORE_MAL, 153, 40),
       new Token(TokenType.ID, CORE_MAL, 153, 47, "A4"),
-
-      // 154:   A8 [a8Sub]   *    <-- L4 --> *    [a8Super] A8
       new Token(TokenType.ID, CORE_MAL, 154, 3, "A8"),
       new Token(TokenType.LBRACKET, CORE_MAL, 154, 6),
       new Token(TokenType.ID, CORE_MAL, 154, 7, "a8Sub"),
@@ -604,8 +599,6 @@ public class TestAllFeatures extends MalTest {
       new Token(TokenType.ID, CORE_MAL, 154, 38, "a8Super"),
       new Token(TokenType.RBRACKET, CORE_MAL, 154, 45),
       new Token(TokenType.ID, CORE_MAL, 154, 47, "A8"),
-
-      // 155: }
       new Token(TokenType.RCURLY, CORE_MAL, 155, 1),
       new Token(TokenType.EOF, CORE_MAL, 156, 1)
     };
@@ -650,10 +643,18 @@ public class TestAllFeatures extends MalTest {
             new Position(CORE_MAL, 1, 1),
             new AST.ID(new Position(CORE_MAL, 1, 10), "C1"),
             Arrays.asList(
-                new AST.Meta(new Position(CORE_MAL, 2, 3), AST.MetaType.INFO, "This is C1"),
-                new AST.Meta(new Position(CORE_MAL, 3, 3), AST.MetaType.ASSUMPTIONS, "None for C1"),
                 new AST.Meta(
-                    new Position(CORE_MAL, 4, 3), AST.MetaType.RATIONALE, "Reasoning for C1")),
+                    new Position(CORE_MAL, 2, 3),
+                    new ID(new Position(CORE_MAL, 2, 3), "user"),
+                    "This is C1"),
+                new AST.Meta(
+                    new Position(CORE_MAL, 3, 3),
+                    new ID(new Position(CORE_MAL, 3, 3), "modeler"),
+                    "None for C1"),
+                new AST.Meta(
+                    new Position(CORE_MAL, 4, 3),
+                    new ID(new Position(CORE_MAL, 4, 3), "developer"),
+                    "Reasoning for C1")),
             new ArrayList<AST.Asset>()),
         categories.get(0));
     assertCategory(
@@ -679,15 +680,15 @@ public class TestAllFeatures extends MalTest {
                             Arrays.asList(
                                 new AST.Meta(
                                     new Position(CORE_MAL, 13, 7),
-                                    AST.MetaType.INFO,
+                                    new ID(new Position(CORE_MAL, 13, 7), "user"),
                                     "This is a1Attack1"),
                                 new AST.Meta(
                                     new Position(CORE_MAL, 14, 7),
-                                    AST.MetaType.ASSUMPTIONS,
+                                    new ID(new Position(CORE_MAL, 14, 7), "modeler"),
                                     "None for a1Attack1"),
                                 new AST.Meta(
                                     new Position(CORE_MAL, 15, 7),
-                                    AST.MetaType.RATIONALE,
+                                    new ID(new Position(CORE_MAL, 15, 7), "developer"),
                                     "Reasoning for a1Attack1")),
                             Optional.empty(),
                             Optional.empty()),
@@ -705,7 +706,7 @@ public class TestAllFeatures extends MalTest {
                             Arrays.asList(
                                 new AST.Meta(
                                     new Position(CORE_MAL, 18, 7),
-                                    AST.MetaType.INFO,
+                                    new ID(new Position(CORE_MAL, 18, 7), "user"),
                                     "This is a1Attack2")),
                             Optional.empty(),
                             Optional.of(
@@ -746,7 +747,7 @@ public class TestAllFeatures extends MalTest {
                             Arrays.asList(
                                 new AST.Meta(
                                     new Position(CORE_MAL, 21, 7),
-                                    AST.MetaType.RATIONALE,
+                                    new ID(new Position(CORE_MAL, 21, 7), "developer"),
                                     "Reasoning for a1Defense")),
                             Optional.empty(),
                             Optional.empty()),
@@ -800,7 +801,7 @@ public class TestAllFeatures extends MalTest {
                             Arrays.asList(
                                 new AST.Meta(
                                     new Position(CORE_MAL, 29, 7),
-                                    AST.MetaType.ASSUMPTIONS,
+                                    new ID(new Position(CORE_MAL, 29, 7), "modeler"),
                                     "None for a1Exist2")),
                             Optional.of(
                                 new AST.Requires(
@@ -1112,7 +1113,9 @@ public class TestAllFeatures extends MalTest {
                     Optional.of(new AST.ID(new Position(CORE_MAL, 63, 29), "A1")),
                     Arrays.asList(
                         new AST.Meta(
-                            new Position(CORE_MAL, 64, 5), AST.MetaType.INFO, "This is A3")),
+                            new Position(CORE_MAL, 64, 5),
+                            new ID(new Position(CORE_MAL, 64, 5), "user"),
+                            "This is A3")),
                     Arrays.asList(
                         new AST.AttackStep(
                             new Position(CORE_MAL, 67, 5),
@@ -1197,7 +1200,9 @@ public class TestAllFeatures extends MalTest {
             new AST.ID(new Position(CORE_MAL, 80, 10), "C2"),
             Arrays.asList(
                 new AST.Meta(
-                    new Position(CORE_MAL, 81, 3), AST.MetaType.ASSUMPTIONS, "None for C2")),
+                    new Position(CORE_MAL, 81, 3),
+                    new ID(new Position(CORE_MAL, 81, 3), "modeler"),
+                    "None for C2")),
             Arrays.asList(
                 new AST.Asset(
                     new Position(CORE_MAL, 83, 3),
@@ -1206,13 +1211,17 @@ public class TestAllFeatures extends MalTest {
                     Optional.empty(),
                     Arrays.asList(
                         new AST.Meta(
-                            new Position(CORE_MAL, 84, 5), AST.MetaType.ASSUMPTIONS, "None for A4"),
+                            new Position(CORE_MAL, 84, 5),
+                            new ID(new Position(CORE_MAL, 84, 5), "modeler"),
+                            "None for A4"),
                         new AST.Meta(
                             new Position(CORE_MAL, 85, 5),
-                            AST.MetaType.RATIONALE,
+                            new ID(new Position(CORE_MAL, 85, 5), "developer"),
                             "Reasoning for A4"),
                         new AST.Meta(
-                            new Position(CORE_MAL, 86, 5), AST.MetaType.INFO, "This is A4")),
+                            new Position(CORE_MAL, 86, 5),
+                            new ID(new Position(CORE_MAL, 86, 5), "user"),
+                            "This is A4")),
                     Arrays.asList(
                         new AST.AttackStep(
                             new Position(CORE_MAL, 89, 5),
@@ -1286,7 +1295,9 @@ public class TestAllFeatures extends MalTest {
             new AST.ID(new Position(CORE_MAL, 98, 10), "C2"),
             Arrays.asList(
                 new AST.Meta(
-                    new Position(CORE_MAL, 99, 3), AST.MetaType.RATIONALE, "Reasoning for C2")),
+                    new Position(CORE_MAL, 99, 3),
+                    new ID(new Position(CORE_MAL, 99, 3), "developer"),
+                    "Reasoning for C2")),
             Arrays.asList(
                 new AST.Asset(
                     new Position(CORE_MAL, 101, 3),
@@ -1296,7 +1307,7 @@ public class TestAllFeatures extends MalTest {
                     Arrays.asList(
                         new AST.Meta(
                             new Position(CORE_MAL, 102, 5),
-                            AST.MetaType.ASSUMPTIONS,
+                            new ID(new Position(CORE_MAL, 102, 5), "modeler"),
                             "None for A5")),
                     new ArrayList<AST.AttackStep>(),
                     new ArrayList<AST.Variable>()),
@@ -1308,7 +1319,7 @@ public class TestAllFeatures extends MalTest {
                     Arrays.asList(
                         new AST.Meta(
                             new Position(CORE_MAL, 106, 5),
-                            AST.MetaType.RATIONALE,
+                            new ID(new Position(CORE_MAL, 106, 5), "developer"),
                             "Reasoning for A6")),
                     new ArrayList<AST.AttackStep>(),
                     new ArrayList<AST.Variable>()))),
@@ -1605,16 +1616,17 @@ public class TestAllFeatures extends MalTest {
         lang,
         "C1",
         new String[] {"A1", "A2", "A3"},
-        new Lang.Meta()
-            .setInfo("This is C1")
-            .setAssumptions("None for C1")
-            .setRationale("Reasoning for C1"));
+        Map.ofEntries(
+            Map.entry("user", "This is C1"),
+            Map.entry("modeler", "None for C1"),
+            Map.entry("developer", "Reasoning for C1")));
     assertLangCategory(
         lang,
         "C2",
         new String[] {"A4", "A5", "A6"},
-        new Lang.Meta().setAssumptions("None for C2").setRationale("Reasoning for C2"));
-    assertLangCategory(lang, "C3", new String[] {"A7", "A8", "A9"}, new Lang.Meta());
+        Map.ofEntries(
+            Map.entry("modeler", "None for C2"), Map.entry("developer", "Reasoning for C2")));
+    assertLangCategory(lang, "C3", new String[] {"A7", "A8", "A9"}, new HashMap<>());
   }
 
   private static void assertAssets(Lang lang) {
@@ -1631,7 +1643,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA1(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A1", false, "C1", null, new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "A1", false, "C1", null, new HashMap<>());
     // Check fields
     assertEquals(5, asset.getFields().size());
     assertLangField(asset, "a4", 1, Integer.MAX_VALUE);
@@ -1652,10 +1664,10 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta()
-                .setInfo("This is a1Attack1")
-                .setAssumptions("None for a1Attack1")
-                .setRationale("Reasoning for a1Attack1"));
+            Map.ofEntries(
+                Map.entry("user", "This is a1Attack1"),
+                Map.entry("modeler", "None for a1Attack1"),
+                Map.entry("developer", "Reasoning for a1Attack1")));
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(true, false, false));
     assertLangTTC(attackStep, null);
@@ -1790,7 +1802,7 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta().setInfo("This is a1Attack2"));
+            Map.ofEntries(Map.entry("user", "This is a1Attack2")));
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(true, true, false));
     assertLangTTC(attackStep, new Lang.TTCFunc(new Distributions.Zero()));
@@ -1873,7 +1885,8 @@ public class TestAllFeatures extends MalTest {
             true,
             false,
             false,
-            new Lang.Meta().setRationale("Reasoning for a1Defense"));
+            Map.ofEntries(Map.entry("developer", "Reasoning for a1Defense")));
+
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, new Lang.TTCFunc(new Distributions.Bernoulli(0.5)));
@@ -1894,7 +1907,7 @@ public class TestAllFeatures extends MalTest {
             true,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, new Lang.TTCFunc(new Distributions.Disabled()));
@@ -1923,7 +1936,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -1954,7 +1967,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             false,
-            new Lang.Meta().setAssumptions("None for a1Exist2"));
+            Map.ofEntries(Map.entry("modeler", "None for a1Exist2")));
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2052,7 +2065,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2110,7 +2123,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2172,7 +2185,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA2(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A2", false, "C1", "A1", new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "A2", false, "C1", "A1", new HashMap<>());
     // Check fields
     assertEquals(0, asset.getFields().size());
     // Check attack steps
@@ -2188,7 +2201,7 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             true,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(false, false, false));
     assertLangTTC(attackStep, null);
@@ -2238,7 +2251,7 @@ public class TestAllFeatures extends MalTest {
     // Check attack step "a1Attack2"
     attackStep =
         assertGetLangAttackStep(
-            asset, "a1Attack2", Lang.AttackStepType.ALL, true, false, false, true, new Lang.Meta());
+            asset, "a1Attack2", Lang.AttackStepType.ALL, true, false, false, true, new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(true, true, true));
     assertLangTTC(attackStep, null);
@@ -2286,7 +2299,7 @@ public class TestAllFeatures extends MalTest {
             true,
             false,
             true,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, new Lang.TTCFunc(new Distributions.Enabled()));
@@ -2345,7 +2358,7 @@ public class TestAllFeatures extends MalTest {
             true,
             false,
             true,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2382,7 +2395,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             true,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2421,7 +2434,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             true,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2453,7 +2466,8 @@ public class TestAllFeatures extends MalTest {
 
   private static void assertAssetA3(Lang lang) {
     var asset =
-        assertGetLangAsset(lang, "A3", true, "C1", "A1", new Lang.Meta().setInfo("This is A3"));
+        assertGetLangAsset(
+            lang, "A3", true, "C1", "A1", Map.ofEntries(Map.entry("user", "This is A3")));
     // Check fields
     assertEquals(1, asset.getFields().size());
     assertLangField(asset, "a6", 0, Integer.MAX_VALUE);
@@ -2470,7 +2484,7 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(true, true, true));
     assertLangTTC(attackStep, null);
@@ -2484,7 +2498,7 @@ public class TestAllFeatures extends MalTest {
     // Check attack step "AT"
     attackStep =
         assertGetLangAttackStep(
-            asset, "AT", Lang.AttackStepType.ALL, false, false, false, false, new Lang.Meta());
+            asset, "AT", Lang.AttackStepType.ALL, false, false, false, false, new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2523,10 +2537,10 @@ public class TestAllFeatures extends MalTest {
             true,
             "C2",
             null,
-            new Lang.Meta()
-                .setAssumptions("None for A4")
-                .setRationale("Reasoning for A4")
-                .setInfo("This is A4"));
+            Map.ofEntries(
+                Map.entry("user", "This is A4"),
+                Map.entry("developer", "Reasoning for A4"),
+                Map.entry("modeler", "None for A4")));
     // Check fields
     assertEquals(2, asset.getFields().size());
     assertLangField(asset, "a1", 1, 1);
@@ -2537,7 +2551,7 @@ public class TestAllFeatures extends MalTest {
     // Check attack step "a"
     var attackStep =
         assertGetLangAttackStep(
-            asset, "a", Lang.AttackStepType.ANY, false, false, false, false, new Lang.Meta());
+            asset, "a", Lang.AttackStepType.ANY, false, false, false, false, new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2617,7 +2631,7 @@ public class TestAllFeatures extends MalTest {
   private static void assertAssetA5(Lang lang) {
     var asset =
         assertGetLangAsset(
-            lang, "A5", false, "C2", "A4", new Lang.Meta().setAssumptions("None for A5"));
+            lang, "A5", false, "C2", "A4", Map.ofEntries(Map.entry("modeler", "None for A5")));
     // Check fields
     assertEquals(1, asset.getFields().size());
     assertLangField(asset, "a6", 0, Integer.MAX_VALUE);
@@ -2628,7 +2642,12 @@ public class TestAllFeatures extends MalTest {
   private static void assertAssetA6(Lang lang) {
     var asset =
         assertGetLangAsset(
-            lang, "A6", true, "C2", "A4", new Lang.Meta().setRationale("Reasoning for A6"));
+            lang,
+            "A6",
+            true,
+            "C2",
+            "A4",
+            Map.ofEntries(Map.entry("developer", "Reasoning for A6")));
     // Check fields
     assertEquals(2, asset.getFields().size());
     assertLangField(asset, "a5", 1, 1);
@@ -2638,7 +2657,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA7(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A7", false, "C3", "A3", new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "A7", false, "C3", "A3", new HashMap<>());
     // Check fields
     assertEquals(1, asset.getFields().size());
     assertLangField(asset, "a1", 1, 1);
@@ -2655,7 +2674,7 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2741,7 +2760,7 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2754,7 +2773,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA8(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A8", false, "C3", null, new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "A8", false, "C3", null, new HashMap<>());
     // Check fields
     assertEquals(4, asset.getFields().size());
     assertLangField(asset, "a1", 0, Integer.MAX_VALUE);
@@ -2767,7 +2786,7 @@ public class TestAllFeatures extends MalTest {
     // Check attack step "destroy"
     var attackStep =
         assertGetLangAttackStep(
-            asset, "destroy", Lang.AttackStepType.ALL, false, false, false, false, new Lang.Meta());
+            asset, "destroy", Lang.AttackStepType.ALL, false, false, false, false, new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(true, true, true));
     assertLangTTC(attackStep, new Lang.TTCFunc(new Distributions.Exponential(5)));
@@ -2856,7 +2875,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA9(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A9", false, "C3", null, new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "A9", false, "C3", null, new HashMap<>());
     // Check fields
     assertEquals(0, asset.getFields().size());
     // Check attack steps
@@ -2865,13 +2884,13 @@ public class TestAllFeatures extends MalTest {
 
   private static void assertLinks(Lang lang) {
     assertEquals(8, lang.getLinks().size());
-    assertLangLink(lang, "A1", "a4", "A4", "a1", 0, "L1", new Lang.Meta());
-    assertLangLink(lang, "A5", "a6", "A6", "a5", 1, "L2", new Lang.Meta());
-    assertLangLink(lang, "A1", "a1Sub", "A1", "a1Super", 2, "L3", new Lang.Meta());
-    assertLangLink(lang, "A3", "a6", "A6", "a3", 3, "L3", new Lang.Meta());
-    assertLangLink(lang, "A7", "a1", "A1", "a7", 4, "L3", new Lang.Meta());
-    assertLangLink(lang, "A8", "a1", "A1", "a8", 5, "L4", new Lang.Meta());
-    assertLangLink(lang, "A8", "a4", "A4", "a8", 6, "L4", new Lang.Meta());
-    assertLangLink(lang, "A8", "a8Super", "A8", "a8Sub", 7, "L4", new Lang.Meta());
+    assertLangLink(lang, "A1", "a4", "A4", "a1", 0, "L1", new HashMap<>());
+    assertLangLink(lang, "A5", "a6", "A6", "a5", 1, "L2", new HashMap<>());
+    assertLangLink(lang, "A1", "a1Sub", "A1", "a1Super", 2, "L3", new HashMap<>());
+    assertLangLink(lang, "A3", "a6", "A6", "a3", 3, "L3", new HashMap<>());
+    assertLangLink(lang, "A7", "a1", "A1", "a7", 4, "L3", new HashMap<>());
+    assertLangLink(lang, "A8", "a1", "A1", "a8", 5, "L4", new HashMap<>());
+    assertLangLink(lang, "A8", "a4", "A4", "a8", 6, "L4", new HashMap<>());
+    assertLangLink(lang, "A8", "a8Super", "A8", "a8Sub", 7, "L4", new HashMap<>());
   }
 }

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/allfeatures/TestAllFeatures.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/allfeatures/TestAllFeatures.java
@@ -36,7 +36,6 @@ import static org.mal_lang.compiler.test.lib.AssertToken.assertTokens;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1626,7 +1625,7 @@ public class TestAllFeatures extends MalTest {
         new String[] {"A4", "A5", "A6"},
         Map.ofEntries(
             Map.entry("modeler", "None for C2"), Map.entry("developer", "Reasoning for C2")));
-    assertLangCategory(lang, "C3", new String[] {"A7", "A8", "A9"}, new HashMap<>());
+    assertLangCategory(lang, "C3", new String[] {"A7", "A8", "A9"}, Map.of());
   }
 
   private static void assertAssets(Lang lang) {
@@ -1643,7 +1642,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA1(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A1", false, "C1", null, new HashMap<>());
+    var asset = assertGetLangAsset(lang, "A1", false, "C1", null, Map.of());
     // Check fields
     assertEquals(5, asset.getFields().size());
     assertLangField(asset, "a4", 1, Integer.MAX_VALUE);
@@ -1907,7 +1906,7 @@ public class TestAllFeatures extends MalTest {
             true,
             false,
             false,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, new Lang.TTCFunc(new Distributions.Disabled()));
@@ -1936,7 +1935,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             false,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2065,7 +2064,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             false,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2123,7 +2122,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             false,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2185,7 +2184,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA2(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A2", false, "C1", "A1", new HashMap<>());
+    var asset = assertGetLangAsset(lang, "A2", false, "C1", "A1", Map.of());
     // Check fields
     assertEquals(0, asset.getFields().size());
     // Check attack steps
@@ -2201,7 +2200,7 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             true,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(false, false, false));
     assertLangTTC(attackStep, null);
@@ -2251,7 +2250,7 @@ public class TestAllFeatures extends MalTest {
     // Check attack step "a1Attack2"
     attackStep =
         assertGetLangAttackStep(
-            asset, "a1Attack2", Lang.AttackStepType.ALL, true, false, false, true, new HashMap<>());
+            asset, "a1Attack2", Lang.AttackStepType.ALL, true, false, false, true, Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(true, true, true));
     assertLangTTC(attackStep, null);
@@ -2299,7 +2298,7 @@ public class TestAllFeatures extends MalTest {
             true,
             false,
             true,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, new Lang.TTCFunc(new Distributions.Enabled()));
@@ -2358,7 +2357,7 @@ public class TestAllFeatures extends MalTest {
             true,
             false,
             true,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2395,7 +2394,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             true,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2434,7 +2433,7 @@ public class TestAllFeatures extends MalTest {
             false,
             true,
             true,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2484,7 +2483,7 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             false,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(true, true, true));
     assertLangTTC(attackStep, null);
@@ -2498,7 +2497,7 @@ public class TestAllFeatures extends MalTest {
     // Check attack step "AT"
     attackStep =
         assertGetLangAttackStep(
-            asset, "AT", Lang.AttackStepType.ALL, false, false, false, false, new HashMap<>());
+            asset, "AT", Lang.AttackStepType.ALL, false, false, false, false, Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2551,7 +2550,7 @@ public class TestAllFeatures extends MalTest {
     // Check attack step "a"
     var attackStep =
         assertGetLangAttackStep(
-            asset, "a", Lang.AttackStepType.ANY, false, false, false, false, new HashMap<>());
+            asset, "a", Lang.AttackStepType.ANY, false, false, false, false, Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2657,7 +2656,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA7(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A7", false, "C3", "A3", new HashMap<>());
+    var asset = assertGetLangAsset(lang, "A7", false, "C3", "A3", Map.of());
     // Check fields
     assertEquals(1, asset.getFields().size());
     assertLangField(asset, "a1", 1, 1);
@@ -2674,7 +2673,7 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             false,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2760,7 +2759,7 @@ public class TestAllFeatures extends MalTest {
             false,
             false,
             false,
-            new HashMap<>());
+            Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -2773,7 +2772,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA8(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A8", false, "C3", null, new HashMap<>());
+    var asset = assertGetLangAsset(lang, "A8", false, "C3", null, Map.of());
     // Check fields
     assertEquals(4, asset.getFields().size());
     assertLangField(asset, "a1", 0, Integer.MAX_VALUE);
@@ -2786,7 +2785,7 @@ public class TestAllFeatures extends MalTest {
     // Check attack step "destroy"
     var attackStep =
         assertGetLangAttackStep(
-            asset, "destroy", Lang.AttackStepType.ALL, false, false, false, false, new HashMap<>());
+            asset, "destroy", Lang.AttackStepType.ALL, false, false, false, false, Map.of());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, new Lang.CIA(true, true, true));
     assertLangTTC(attackStep, new Lang.TTCFunc(new Distributions.Exponential(5)));
@@ -2875,7 +2874,7 @@ public class TestAllFeatures extends MalTest {
   }
 
   private static void assertAssetA9(Lang lang) {
-    var asset = assertGetLangAsset(lang, "A9", false, "C3", null, new HashMap<>());
+    var asset = assertGetLangAsset(lang, "A9", false, "C3", null, Map.of());
     // Check fields
     assertEquals(0, asset.getFields().size());
     // Check attack steps
@@ -2884,13 +2883,13 @@ public class TestAllFeatures extends MalTest {
 
   private static void assertLinks(Lang lang) {
     assertEquals(8, lang.getLinks().size());
-    assertLangLink(lang, "A1", "a4", "A4", "a1", 0, "L1", new HashMap<>());
-    assertLangLink(lang, "A5", "a6", "A6", "a5", 1, "L2", new HashMap<>());
-    assertLangLink(lang, "A1", "a1Sub", "A1", "a1Super", 2, "L3", new HashMap<>());
-    assertLangLink(lang, "A3", "a6", "A6", "a3", 3, "L3", new HashMap<>());
-    assertLangLink(lang, "A7", "a1", "A1", "a7", 4, "L3", new HashMap<>());
-    assertLangLink(lang, "A8", "a1", "A1", "a8", 5, "L4", new HashMap<>());
-    assertLangLink(lang, "A8", "a4", "A4", "a8", 6, "L4", new HashMap<>());
-    assertLangLink(lang, "A8", "a8Super", "A8", "a8Sub", 7, "L4", new HashMap<>());
+    assertLangLink(lang, "A1", "a4", "A4", "a1", 0, "L1", Map.of());
+    assertLangLink(lang, "A5", "a6", "A6", "a5", 1, "L2", Map.of());
+    assertLangLink(lang, "A1", "a1Sub", "A1", "a1Super", 2, "L3", Map.of());
+    assertLangLink(lang, "A3", "a6", "A6", "a3", 3, "L3", Map.of());
+    assertLangLink(lang, "A7", "a1", "A1", "a7", 4, "L3", Map.of());
+    assertLangLink(lang, "A8", "a1", "A1", "a8", 5, "L4", Map.of());
+    assertLangLink(lang, "A8", "a4", "A4", "a8", 6, "L4", Map.of());
+    assertLangLink(lang, "A8", "a8Super", "A8", "a8Sub", 7, "L4", Map.of());
   }
 }

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/AssertLang.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/AssertLang.java
@@ -45,17 +45,17 @@ public final class AssertLang {
     return LangConverter.convert(ast);
   }
 
-  public static void assertLangMeta(Lang.Meta expected, Lang.Meta actual, String location) {
-    assertEquals(
-        expected.getInfo(), actual.getInfo(), String.format("Wrong info string at %s", location));
-    assertEquals(
-        expected.getAssumptions(),
-        actual.getAssumptions(),
-        String.format("Wrong assumptions string at %s", location));
-    assertEquals(
-        expected.getRationale(),
-        actual.getRationale(),
-        String.format("Wrong rationale string at %s", location));
+  public static void assertLangMeta(
+      Map<String, String> expected, Map<String, String> actual, String location) {
+    assertEquals(expected.size(), actual.size(), "Wrong number of metas");
+    for (var meta : expected.entrySet()) {
+      assertTrue(
+          actual.containsKey(meta.getKey()), String.format("Expected meta #%s", meta.getKey()));
+      assertEquals(
+          meta.getValue(),
+          actual.get(meta.getKey()),
+          String.format("Wrong value for meta #%s", meta.getKey()));
+    }
   }
 
   public static void assertLangDefines(Map<String, String> expected, Map<String, String> actual) {
@@ -72,7 +72,7 @@ public final class AssertLang {
   }
 
   public static void assertLangCategory(
-      Lang lang, String name, String[] expectedAssets, Lang.Meta meta) {
+      Lang lang, String name, String[] expectedAssets, Map<String, String> meta) {
     var categories = lang.getCategories();
     assertTrue(categories.containsKey(name), String.format("Expected category %s", name));
     var category = categories.get(name);
@@ -107,7 +107,7 @@ public final class AssertLang {
       boolean isAbstract,
       String category,
       String superAsset,
-      Lang.Meta meta) {
+      Map<String, String> meta) {
     var assets = lang.getAssets();
     assertTrue(assets.containsKey(name), String.format("Expected asset %s", name));
     var asset = assets.get(name);
@@ -176,7 +176,7 @@ public final class AssertLang {
       boolean isDefense,
       boolean isConditionalDefense,
       boolean hasParent,
-      Lang.Meta meta) {
+      Map<String, String> meta) {
     var attackSteps = asset.getAttackSteps();
     assertTrue(
         attackSteps.containsKey(name),
@@ -464,7 +464,7 @@ public final class AssertLang {
       String asset2Field,
       int idx,
       String name,
-      Lang.Meta meta) {
+      Map<String, String> meta) {
     var link = lang.getLinks().get(idx);
     var leftField = lang.getAsset(asset1).getField(asset1Field);
     var rightField = lang.getAsset(asset2).getField(asset2Field);

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestAnalyzer.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestAnalyzer.java
@@ -31,9 +31,9 @@ public class TestAnalyzer extends MalTest {
       "[ANALYZER ERROR] Missing required define '#version: \"\"'",
       "[ANALYZER ERROR] <bad1.mal:4:1> Define 'custom' previously defined at <bad1.mal:3:1>",
       "[ANALYZER WARNING] <bad1.mal:5:10> Category 'emp' contains no assets or metadata",
-      "[ANALYZER ERROR] <bad1.mal:11:3> Metadata 'info' previously defined at <bad1.mal:10:3>",
-      "[ANALYZER ERROR] <bad1.mal:12:3> Metadata 'rationale' previously defined at <bad1.mal:7:3>",
-      "[ANALYZER ERROR] <bad1.mal:16:5> Metadata 'rationale' previously defined at <bad1.mal:15:5>",
+      "[ANALYZER ERROR] <bad1.mal:11:3> Metadata user previously defined at <bad1.mal:10:3>",
+      "[ANALYZER ERROR] <bad1.mal:12:3> Metadata developer previously defined at <bad1.mal:7:3>",
+      "[ANALYZER ERROR] <bad1.mal:16:5> Metadata developer previously defined at <bad1.mal:15:5>",
       "[ANALYZER ERROR] <bad1.mal:20:8> Last step is not attack step",
       "[ANALYZER WARNING] <bad1.mal:21:7> Step 'c' defined as variable at <bad1.mal:19:11> and field at <bad1.mal:49:26>",
       "[ANALYZER ERROR] <bad1.mal:22:7> Attack step 'compromise' previously defined at <bad1.mal:18:7>",
@@ -54,7 +54,7 @@ public class TestAnalyzer extends MalTest {
       "[ANALYZER ERROR] <bad1.mal:43:7> Previous asset '_C' is not of type '_A'",
       "[ANALYZER ERROR] <bad1.mal:44:7> Defenses cannot have CIA classifications",
       "[ANALYZER ERROR] <bad1.mal:50:7> Field _A.a previously defined at <bad1.mal:50:26>",
-      "[ANALYZER ERROR] <bad1.mal:52:6> Metadata 'assumptions' previously defined at <bad1.mal:51:6>",
+      "[ANALYZER ERROR] <bad1.mal:52:6> Metadata modeler previously defined at <bad1.mal:51:6>",
       ""
     };
     assertErrLines(expected);

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestLangConverter.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestLangConverter.java
@@ -28,6 +28,7 @@ import static org.mal_lang.compiler.test.lib.AssertLang.assertLangStepExpr;
 import static org.mal_lang.compiler.test.lib.AssertLang.assertLangTTC;
 import static org.mal_lang.compiler.test.lib.AssertLang.assertLangTags;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -40,7 +41,7 @@ public class TestLangConverter extends MalTest {
   public void testReverse() {
     var lang = assertGetLangClassPath("lang-converter/reverse.mal");
     // localaction
-    var asset = assertGetLangAsset(lang, "LocalAction", false, "CAT", "Action", new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "LocalAction", false, "CAT", "Action", new HashMap<>());
     // compromise
     var attackstep =
         assertGetLangAttackStep(
@@ -51,7 +52,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             true,
-            new Lang.Meta());
+            new HashMap<>());
     // -> (a.ga /\ a.la).compromise
     var step =
         new Lang.StepCollect(
@@ -105,7 +106,7 @@ public class TestLangConverter extends MalTest {
     assertLangStepExpr(step, attackstep.getReaches().get(0));
 
     // action
-    asset = assertGetLangAsset(lang, "Action", false, "CAT", null, new Lang.Meta());
+    asset = assertGetLangAsset(lang, "Action", false, "CAT", null, new HashMap<>());
     // compromise
     attackstep =
         assertGetLangAttackStep(
@@ -116,7 +117,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     step =
         new Lang.StepCollect(
             asset,
@@ -187,12 +188,12 @@ public class TestLangConverter extends MalTest {
   private static void assertCategories(Lang lang) {
     assertEquals(2, lang.getCategories().size());
     assertLangCategory(
-        lang, "Person", new String[] {"User", "Student", "Teacher"}, new Lang.Meta());
+        lang, "Person", new String[] {"User", "Student", "Teacher"}, new HashMap<>());
     assertLangCategory(
         lang,
         "Hardware",
         new String[] {"Computer", "Firewall", "Harddrive", "SecretFolder"},
-        new Lang.Meta());
+        new HashMap<>());
   }
 
   private static void assertAssets(Lang lang) {
@@ -207,7 +208,7 @@ public class TestLangConverter extends MalTest {
   }
 
   private static void assertAssetUser(Lang lang) {
-    var asset = assertGetLangAsset(lang, "User", true, "Person", null, new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "User", true, "Person", null, new HashMap<>());
     // Check fields
     assertEquals(2, asset.getFields().size());
     assertLangField(asset, "firewall", 1, 1);
@@ -225,7 +226,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of("hidden"));
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -292,7 +293,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -344,7 +345,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -399,7 +400,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -441,7 +442,7 @@ public class TestLangConverter extends MalTest {
   }
 
   private static void assertAssetStudent(Lang lang) {
-    var asset = assertGetLangAsset(lang, "Student", false, "Person", "User", new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "Student", false, "Person", "User", new HashMap<>());
     // Check fields
     assertEquals(1, asset.getFields().size());
     assertLangField(asset, "studentComputer", 1, Integer.MAX_VALUE);
@@ -450,7 +451,7 @@ public class TestLangConverter extends MalTest {
   }
 
   private static void assertAssetTeacher(Lang lang) {
-    var asset = assertGetLangAsset(lang, "Teacher", false, "Person", "User", new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "Teacher", false, "Person", "User", new HashMap<>());
     // Check fields
     assertEquals(1, asset.getFields().size());
     assertLangField(asset, "teacherComputer", 1, 1);
@@ -467,9 +468,10 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta()
-                .setInfo(
-                    "An extra level of protection, their school computer must be used to impersonate them."));
+            Map.ofEntries(
+                Map.entry(
+                    "user",
+                    "An extra level of protection, their school computer must be used to impersonate them.")));
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -487,7 +489,7 @@ public class TestLangConverter extends MalTest {
   }
 
   private static void assertAssetComputer(Lang lang) {
-    var asset = assertGetLangAsset(lang, "Computer", false, "Hardware", null, new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "Computer", false, "Hardware", null, new HashMap<>());
     // Check fields
     assertEquals(6, asset.getFields().size());
     assertLangField(asset, "student", 1, 1);
@@ -509,7 +511,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -535,7 +537,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -583,8 +585,9 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta()
-                .setInfo("Retrieval of password is only possible if password is unencrypted"));
+            Map.ofEntries(
+                Map.entry(
+                    "user", "Retrieval of password is only possible if password is unencrypted")));
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -647,7 +650,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     // ExponentialDistribution(0.05) * GammaDistribution(1.2, 1.7)
@@ -693,7 +696,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -759,7 +762,7 @@ public class TestLangConverter extends MalTest {
             true,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -784,7 +787,7 @@ public class TestLangConverter extends MalTest {
             false,
             true,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -826,7 +829,7 @@ public class TestLangConverter extends MalTest {
   }
 
   private static void assertAssetFirewall(Lang lang) {
-    var asset = assertGetLangAsset(lang, "Firewall", false, "Hardware", null, new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "Firewall", false, "Hardware", null, new HashMap<>());
     // Check fields
     assertEquals(2, asset.getFields().size());
     assertLangField(asset, "computer", 0, Integer.MAX_VALUE);
@@ -844,7 +847,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -952,7 +955,7 @@ public class TestLangConverter extends MalTest {
   }
 
   private static void assertAssetHarddrive(Lang lang) {
-    var asset = assertGetLangAsset(lang, "Harddrive", false, "Hardware", null, new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "Harddrive", false, "Hardware", null, new HashMap<>());
     // Check fields
     assertEquals(3, asset.getFields().size());
     assertLangField(asset, "extHDComputer", 1, 1);
@@ -971,7 +974,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -1052,7 +1055,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -1130,7 +1133,7 @@ public class TestLangConverter extends MalTest {
   }
 
   private static void assertAssetSecretFolder(Lang lang) {
-    var asset = assertGetLangAsset(lang, "SecretFolder", false, "Hardware", null, new Lang.Meta());
+    var asset = assertGetLangAsset(lang, "SecretFolder", false, "Hardware", null, new HashMap<>());
     // Check fields
     assertEquals(3, asset.getFields().size());
     assertLangField(asset, "internalHD", 1, 1);
@@ -1149,7 +1152,7 @@ public class TestLangConverter extends MalTest {
             false,
             false,
             false,
-            new Lang.Meta());
+            new HashMap<>());
     assertLangTags(attackStep, List.of());
     assertLangCIA(attackStep, null);
     assertLangTTC(attackStep, null);
@@ -1194,15 +1197,15 @@ public class TestLangConverter extends MalTest {
   private static void assertLinks(Lang lang) {
     assertEquals(9, lang.getLinks().size());
     assertLangLink(
-        lang, "Computer", "student", "Student", "studentComputer", 0, "Use", new Lang.Meta());
+        lang, "Computer", "student", "Student", "studentComputer", 0, "Use", new HashMap<>());
     assertLangLink(
-        lang, "Computer", "teacher", "Teacher", "teacherComputer", 1, "Use", new Lang.Meta());
+        lang, "Computer", "teacher", "Teacher", "teacherComputer", 1, "Use", new HashMap<>());
     assertLangLink(
-        lang, "Computer", "firewall", "Firewall", "computer", 2, "Protect", new Lang.Meta());
-    assertLangLink(lang, "Firewall", "user", "User", "firewall", 3, "Protect", new Lang.Meta());
-    assertLangLink(lang, "Computer", "user", "User", "computer", 4, "Storage", new Lang.Meta());
+        lang, "Computer", "firewall", "Firewall", "computer", 2, "Protect", new HashMap<>());
+    assertLangLink(lang, "Firewall", "user", "User", "firewall", 3, "Protect", new HashMap<>());
+    assertLangLink(lang, "Computer", "user", "User", "computer", 4, "Storage", new HashMap<>());
     assertLangLink(
-        lang, "Computer", "externalHD", "Harddrive", "extHDComputer", 5, "Use", new Lang.Meta());
+        lang, "Computer", "externalHD", "Harddrive", "extHDComputer", 5, "Use", new HashMap<>());
     assertLangLink(
         lang,
         "Computer",
@@ -1211,10 +1214,10 @@ public class TestLangConverter extends MalTest {
         "intHDComputer",
         6,
         "Contain",
-        new Lang.Meta());
+        new HashMap<>());
     assertLangLink(
-        lang, "Harddrive", "folder", "SecretFolder", "internalHD", 7, "Contain", new Lang.Meta());
+        lang, "Harddrive", "folder", "SecretFolder", "internalHD", 7, "Contain", new HashMap<>());
     assertLangLink(
-        lang, "SecretFolder", "subFolder", "SecretFolder", "folder", 8, "Contain", new Lang.Meta());
+        lang, "SecretFolder", "subFolder", "SecretFolder", "folder", 8, "Contain", new HashMap<>());
   }
 }

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestLexer.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestLexer.java
@@ -90,8 +90,6 @@ public class TestLexer extends MalTest {
     TokenType[] tokenTypes = {
       TokenType.INCLUDE,
       TokenType.INFO,
-      TokenType.ASSUMPTIONS,
-      TokenType.RATIONALE,
       TokenType.CATEGORY,
       TokenType.ABSTRACT,
       TokenType.ASSET,

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestParser.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestParser.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.mal_lang.compiler.lib.AST;
+import org.mal_lang.compiler.lib.AST.ID;
 import org.mal_lang.compiler.lib.Position;
 import org.mal_lang.compiler.test.MalTest;
 
@@ -115,7 +116,10 @@ public class TestParser extends MalTest {
             new Position(CATEGORIES_MAL, 6, 1),
             new AST.ID(new Position(CATEGORIES_MAL, 6, 10), "C2"),
             Arrays.asList(
-                new AST.Meta(new Position(CATEGORIES_MAL, 7, 3), AST.MetaType.ASSUMPTIONS, "none")),
+                new AST.Meta(
+                    new Position(CATEGORIES_MAL, 7, 3),
+                    new ID(new Position(CATEGORIES_MAL, 7, 3), "modeler"),
+                    "none")),
             Arrays.asList(
                 new AST.Asset(
                     new Position(CATEGORIES_MAL, 9, 3),
@@ -140,14 +144,20 @@ public class TestParser extends MalTest {
             new AST.ID(new Position(CATEGORIES_MAL, 13, 10), "C3"),
             Arrays.asList(
                 new AST.Meta(
-                    new Position(CATEGORIES_MAL, 14, 3), AST.MetaType.INFO, "this is first C3"),
+                    new Position(CATEGORIES_MAL, 14, 3),
+                    new ID(new Position(CATEGORIES_MAL, 14, 3), "user"),
+                    "this is first C3"),
                 new AST.Meta(
-                    new Position(CATEGORIES_MAL, 15, 3), AST.MetaType.INFO, "another info"),
+                    new Position(CATEGORIES_MAL, 15, 3),
+                    new ID(new Position(CATEGORIES_MAL, 15, 3), "user"),
+                    "another info"),
                 new AST.Meta(
-                    new Position(CATEGORIES_MAL, 16, 3), AST.MetaType.RATIONALE, "just to test"),
+                    new Position(CATEGORIES_MAL, 16, 3),
+                    new ID(new Position(CATEGORIES_MAL, 16, 3), "developer"),
+                    "just to test"),
                 new AST.Meta(
                     new Position(CATEGORIES_MAL, 17, 3),
-                    AST.MetaType.ASSUMPTIONS,
+                    new ID(new Position(CATEGORIES_MAL, 17, 3), "developer"),
                     "will not run through the analyzer")),
             new ArrayList<AST.Asset>()),
         categories.get(2));
@@ -211,11 +221,17 @@ public class TestParser extends MalTest {
             new AST.ID(new Position(ASSOCIATIONS_MAL, 47, 31), "a"),
             new AST.ID(new Position(ASSOCIATIONS_MAL, 47, 34), "A2"),
             Arrays.asList(
-                new AST.Meta(new Position(ASSOCIATIONS_MAL, 48, 6), AST.MetaType.INFO, "testing"),
-                new AST.Meta(new Position(ASSOCIATIONS_MAL, 49, 6), AST.MetaType.RATIONALE, "hej"),
+                new AST.Meta(
+                    new Position(ASSOCIATIONS_MAL, 48, 6),
+                    new ID(new Position(ASSOCIATIONS_MAL, 48, 6), "user"),
+                    "testing"),
+                new AST.Meta(
+                    new Position(ASSOCIATIONS_MAL, 49, 6),
+                    new ID(new Position(ASSOCIATIONS_MAL, 49, 6), "developer"),
+                    "hej"),
                 new AST.Meta(
                     new Position(ASSOCIATIONS_MAL, 50, 6),
-                    AST.MetaType.ASSUMPTIONS,
+                    new ID(new Position(ASSOCIATIONS_MAL, 50, 6), "modeler"),
                     "\"!\"!\"!\""))),
         associations.get(36));
     assertEquals(0, ast.getDefines().size());
@@ -273,11 +289,18 @@ public class TestParser extends MalTest {
                     new AST.ID(new Position(ASSETS_MAL, 2, 9), "A1"),
                     Optional.empty(),
                     Arrays.asList(
-                        new AST.Meta(new Position(ASSETS_MAL, 3, 5), AST.MetaType.INFO, "Info1"),
                         new AST.Meta(
-                            new Position(ASSETS_MAL, 4, 5), AST.MetaType.RATIONALE, "Reason1"),
+                            new Position(ASSETS_MAL, 3, 5),
+                            new ID(new Position(ASSETS_MAL, 3, 5), "user"),
+                            "Info1"),
                         new AST.Meta(
-                            new Position(ASSETS_MAL, 5, 5), AST.MetaType.ASSUMPTIONS, "None1")),
+                            new Position(ASSETS_MAL, 4, 5),
+                            new ID(new Position(ASSETS_MAL, 4, 5), "developer"),
+                            "Reason1"),
+                        new AST.Meta(
+                            new Position(ASSETS_MAL, 5, 5),
+                            new ID(new Position(ASSETS_MAL, 5, 5), "modeler"),
+                            "None1")),
                     new ArrayList<AST.AttackStep>(),
                     new ArrayList<AST.Variable>()),
                 new AST.Asset(
@@ -286,11 +309,18 @@ public class TestParser extends MalTest {
                     new AST.ID(new Position(ASSETS_MAL, 9, 18), "A2"),
                     Optional.empty(),
                     Arrays.asList(
-                        new AST.Meta(new Position(ASSETS_MAL, 10, 5), AST.MetaType.INFO, "Info2"),
                         new AST.Meta(
-                            new Position(ASSETS_MAL, 11, 5), AST.MetaType.RATIONALE, "Reason2"),
+                            new Position(ASSETS_MAL, 10, 5),
+                            new ID(new Position(ASSETS_MAL, 10, 5), "user"),
+                            "Info2"),
                         new AST.Meta(
-                            new Position(ASSETS_MAL, 12, 5), AST.MetaType.ASSUMPTIONS, "None2")),
+                            new Position(ASSETS_MAL, 11, 5),
+                            new ID(new Position(ASSETS_MAL, 11, 5), "developer"),
+                            "Reason2"),
+                        new AST.Meta(
+                            new Position(ASSETS_MAL, 12, 5),
+                            new ID(new Position(ASSETS_MAL, 12, 5), "modeler"),
+                            "None2")),
                     new ArrayList<AST.AttackStep>(),
                     Arrays.asList(
                         new AST.Variable(
@@ -305,11 +335,18 @@ public class TestParser extends MalTest {
                     new AST.ID(new Position(ASSETS_MAL, 17, 9), "A3"),
                     Optional.of(new AST.ID(new Position(ASSETS_MAL, 17, 20), "A1")),
                     Arrays.asList(
-                        new AST.Meta(new Position(ASSETS_MAL, 18, 5), AST.MetaType.INFO, "Info3"),
                         new AST.Meta(
-                            new Position(ASSETS_MAL, 19, 5), AST.MetaType.RATIONALE, "Reason3"),
+                            new Position(ASSETS_MAL, 18, 5),
+                            new ID(new Position(ASSETS_MAL, 18, 5), "user"),
+                            "Info3"),
                         new AST.Meta(
-                            new Position(ASSETS_MAL, 20, 5), AST.MetaType.ASSUMPTIONS, "None3")),
+                            new Position(ASSETS_MAL, 19, 5),
+                            new ID(new Position(ASSETS_MAL, 19, 5), "developer"),
+                            "Reason3"),
+                        new AST.Meta(
+                            new Position(ASSETS_MAL, 20, 5),
+                            new ID(new Position(ASSETS_MAL, 20, 5), "modeler"),
+                            "None3")),
                     Arrays.asList(
                         new AST.AttackStep(
                             new Position(ASSETS_MAL, 22, 5),
@@ -338,11 +375,18 @@ public class TestParser extends MalTest {
                     new AST.ID(new Position(ASSETS_MAL, 26, 18), "A4"),
                     Optional.of(new AST.ID(new Position(ASSETS_MAL, 26, 29), "A2")),
                     Arrays.asList(
-                        new AST.Meta(new Position(ASSETS_MAL, 27, 5), AST.MetaType.INFO, "Info4"),
                         new AST.Meta(
-                            new Position(ASSETS_MAL, 28, 5), AST.MetaType.RATIONALE, "Reason4"),
+                            new Position(ASSETS_MAL, 27, 5),
+                            new ID(new Position(ASSETS_MAL, 27, 5), "user"),
+                            "Info4"),
                         new AST.Meta(
-                            new Position(ASSETS_MAL, 29, 5), AST.MetaType.ASSUMPTIONS, "None4")),
+                            new Position(ASSETS_MAL, 28, 5),
+                            new ID(new Position(ASSETS_MAL, 28, 5), "developer"),
+                            "Reason4"),
+                        new AST.Meta(
+                            new Position(ASSETS_MAL, 29, 5),
+                            new ID(new Position(ASSETS_MAL, 29, 5), "modeler"),
+                            "None4")),
                     Arrays.asList(
                         new AST.AttackStep(
                             new Position(ASSETS_MAL, 31, 5),
@@ -860,7 +904,7 @@ public class TestParser extends MalTest {
                             Arrays.asList(
                                 new AST.Meta(
                                     new Position(ATTACKSTEPS_MAL, 37, 7),
-                                    AST.MetaType.INFO,
+                                    new ID(new Position(ATTACKSTEPS_MAL, 37, 7), "user"),
                                     "Info")),
                             Optional.empty(),
                             Optional.empty()),
@@ -874,11 +918,11 @@ public class TestParser extends MalTest {
                             Arrays.asList(
                                 new AST.Meta(
                                     new Position(ATTACKSTEPS_MAL, 39, 7),
-                                    AST.MetaType.INFO,
+                                    new ID(new Position(ATTACKSTEPS_MAL, 39, 7), "user"),
                                     "Info"),
                                 new AST.Meta(
                                     new Position(ATTACKSTEPS_MAL, 40, 7),
-                                    AST.MetaType.RATIONALE,
+                                    new ID(new Position(ATTACKSTEPS_MAL, 40, 7), "developer"),
                                     "Reason")),
                             Optional.empty(),
                             Optional.empty()),
@@ -896,7 +940,7 @@ public class TestParser extends MalTest {
                             Arrays.asList(
                                 new AST.Meta(
                                     new Position(ATTACKSTEPS_MAL, 42, 7),
-                                    AST.MetaType.INFO,
+                                    new ID(new Position(ATTACKSTEPS_MAL, 42, 7), "user"),
                                     "Info")),
                             Optional.empty(),
                             Optional.empty())),
@@ -1127,7 +1171,7 @@ public class TestParser extends MalTest {
                             Arrays.asList(
                                 new AST.Meta(
                                     new Position(ATTACKSTEPS_MAL, 72, 7),
-                                    AST.MetaType.INFO,
+                                    new ID(new Position(ATTACKSTEPS_MAL, 72, 7), "user"),
                                     "Info")),
                             Optional.of(
                                 new AST.Requires(

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestParserFail.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestParserFail.java
@@ -106,12 +106,12 @@ public class TestParserFail extends MalTest {
     assertSyntaxError(
         "parser/bad-meta1.mal",
         new Position(BAD_META1_MAL, 2, 3),
-        "expected 'info', 'assumptions', 'rationale', or '{', found identifier");
+        "expected 'info' or '{', found identifier");
     assertSyntaxError(
-        "parser/bad-meta2.mal", new Position(BAD_META2_MAL, 2, 8), "expected ':', found '='");
+        "parser/bad-meta2.mal", new Position(BAD_META2_MAL, 2, 13), "expected ':', found '='");
     assertSyntaxError(
         "parser/bad-meta3.mal",
-        new Position(BAD_META3_MAL, 2, 9),
+        new Position(BAD_META3_MAL, 2, 14),
         "expected string literal, found identifier");
   }
 
@@ -136,7 +136,7 @@ public class TestParserFail extends MalTest {
     assertSyntaxError(
         "parser/bad-category1.mal",
         new Position(BAD_CATEGORY1_MAL, 2, 3),
-        "expected 'abstract', 'asset', or '}', found 'info'");
+        "expected 'abstract', 'asset', or '}', found identifier");
   }
 
   @Test
@@ -156,7 +156,7 @@ public class TestParserFail extends MalTest {
     assertSyntaxError(
         "parser/bad-asset4.mal",
         new Position(BAD_ASSET4_MAL, 3, 5),
-        "expected '&', '|', '#', 'E', '!E', 'let', or '}', found 'info'");
+        "expected '&', '|', '#', 'E', '!E', 'let', or '}', found identifier");
   }
 
   @Test
@@ -175,12 +175,12 @@ public class TestParserFail extends MalTest {
         "expected ']', found ')'");
     assertSyntaxError(
         "parser/bad-attackstep4.mal",
-        new Position(BAD_ATTACKSTEP4_MAL, 5, 9),
-        "expected identifier or '(', found 'info'");
+        new Position(BAD_ATTACKSTEP4_MAL, 5, 14),
+        "expected '&', '|', '#', 'E', '!E', 'let', or '}', found 'info'");
     assertSyntaxError(
         "parser/bad-attackstep5.mal",
-        new Position(BAD_ATTACKSTEP5_MAL, 5, 9),
-        "expected identifier or '(', found 'info'");
+        new Position(BAD_ATTACKSTEP5_MAL, 5, 14),
+        "expected '&', '|', '#', 'E', '!E', 'let', or '}', found 'info'");
     assertSyntaxError(
         "parser/bad-attackstep6.mal",
         new Position(BAD_ATTACKSTEP6_MAL, 3, 11),

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestParserFail.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/TestParserFail.java
@@ -105,8 +105,8 @@ public class TestParserFail extends MalTest {
   public void testBadMeta() {
     assertSyntaxError(
         "parser/bad-meta1.mal",
-        new Position(BAD_META1_MAL, 2, 3),
-        "expected 'info' or '{', found identifier");
+        new Position(BAD_META1_MAL, 2, 8),
+        "expected 'info', found identifier");
     assertSyntaxError(
         "parser/bad-meta2.mal", new Position(BAD_META2_MAL, 2, 13), "expected ':', found '='");
     assertSyntaxError(

--- a/malcompiler-test/src/test/resources/all-features/core.mal
+++ b/malcompiler-test/src/test/resources/all-features/core.mal
@@ -1,7 +1,7 @@
 category C1
-  info: "This is C1"
-  assumptions: "None for C1"
-  rationale: "Reasoning for C1"
+  user info: "This is C1"
+  modeler info: "None for C1"
+  developer info: "Reasoning for C1"
 {
   // This category only contains meta information
 }
@@ -10,15 +10,15 @@ category C1 {
   asset A1
   {
     | a1Attack1 {C}
-      info: "This is a1Attack1"
-      assumptions: "None for a1Attack1"
-      rationale: "Reasoning for a1Attack1"
+      user info: "This is a1Attack1"
+      modeler info: "None for a1Attack1"
+      developer info: "Reasoning for a1Attack1"
       // No reaches
     & a1Attack2 {I, C} []
-      info: "This is a1Attack2"
+      user info: "This is a1Attack2"
       -> a1Sub[A1]*.a1Attack1
     # a1Defense1 [Bernoulli(0.5)]
-      rationale: "Reasoning for a1Defense"
+      developer info: "Reasoning for a1Defense"
       // No reaches
     # a1Defense2 [Disabled]
       -> a1Attack2
@@ -26,7 +26,7 @@ category C1 {
       <- a1Sub
       /* No reaches */
     E a1Exist2
-      assumptions: "None for a1Exist2"
+      modeler info: "None for a1Exist2"
       <- a7, a1Super.a1Super.a7
       -> (a1Super*)[A2].(a8.destroy)
     !E a1NotExist1
@@ -61,7 +61,7 @@ category C1 {
   }
 
   abstract asset A3 extends A1
-    info: "This is A3"
+    user info: "This is A3"
   {
     let unused = a1Sub
     | a3Attack {A, I, C}
@@ -78,12 +78,12 @@ category C1 {
 category C2 { /* This category is empty */ }
 
 category C2
-  assumptions: "None for C2"
+  modeler info: "None for C2"
 {
   abstract asset A4
-    assumptions: "None for A4"
-    rationale: "Reasoning for A4"
-    info: "This is A4"
+    modeler info: "None for A4"
+    developer info: "Reasoning for A4"
+    user info: "This is A4"
   {
     let var = a1.a1Sub*
     | a
@@ -96,14 +96,14 @@ category C2
 }
 
 category C2
-  rationale: "Reasoning for C2"
+  developer info: "Reasoning for C2"
 {
   asset A5 extends A4
-    assumptions: "None for A5"
+    modeler info: "None for A5"
   { /* This asset is empty */ }
 
   abstract asset A6 extends A4
-    rationale: "Reasoning for A6"
+    developer info: "Reasoning for A6"
   {
     // Nothing extends this abstract asset
   }

--- a/malcompiler-test/src/test/resources/analyzer/bad1.mal
+++ b/malcompiler-test/src/test/resources/analyzer/bad1.mal
@@ -4,16 +4,16 @@
 #custom: "" // duplicate define
 category emp {} // empty category (warning)
 category cat
-  rationale: "rat"
+  developer info: "rat"
   {}
 category cat
-  info: "category"
-  info: "category" // duplicate info
-  rationale: "rat" // duplicate rationale from different definition
+  user info: "category"
+  user info: "category" // duplicate info
+  developer info: "rat" // duplicate rationale from different definition
   {
   asset _A
-    rationale: "asset"
-    rationale: "asset" // duplicate rationale
+    developer info: "asset"
+    developer info: "asset" // duplicate rationale
     {
     | compromise ->
       let c = a, // variable as field (warning)
@@ -48,6 +48,6 @@ category cat
 associations {
   _A [a] * <-- ac --> * [c] _C
   _A [a] * <-- aa --> * [a] _A // duplicate fields
-     assumptions: "association"
-     assumptions: "association" // duplicate association
+     modeler info: "association"
+     modeler info: "association" // duplicate association
 }

--- a/malcompiler-test/src/test/resources/analyzer/complex-lexer.txt
+++ b/malcompiler-test/src/test/resources/analyzer/complex-lexer.txt
@@ -62,9 +62,10 @@ identifier, <complex.mal:24:25>, User
 '{', <complex.mal:24:30>
 '|', <complex.mal:25:5>
 identifier, <complex.mal:25:7>, accessSchoolComputer
-'info', <complex.mal:26:7>
-':', <complex.mal:26:11>
-string literal, <complex.mal:26:13>, An extra level of protection, their school computer must be used to impersonate them.
+identifier, <complex.mal:26:7>, user
+'info', <complex.mal:26:12>
+':', <complex.mal:26:16>
+string literal, <complex.mal:26:18>, An extra level of protection, their school computer must be used to impersonate them.
 '->', <complex.mal:27:7>
 identifier, <complex.mal:27:10>, compromise
 '}', <complex.mal:28:3>
@@ -91,9 +92,10 @@ identifier, <complex.mal:35:7>, interceptTraffic
 identifier, <complex.mal:36:10>, retrievePassword
 '&', <complex.mal:37:5>
 identifier, <complex.mal:37:7>, retrievePassword
-'info', <complex.mal:38:7>
-':', <complex.mal:38:11>
-string literal, <complex.mal:38:13>, Retrieval of password is only possible if password is unencrypted
+identifier, <complex.mal:38:7>, user
+'info', <complex.mal:38:12>
+':', <complex.mal:38:16>
+string literal, <complex.mal:38:18>, Retrieval of password is only possible if password is unencrypted
 '->', <complex.mal:39:7>
 identifier, <complex.mal:39:10>, user
 '.', <complex.mal:39:14>

--- a/malcompiler-test/src/test/resources/analyzer/complex-parser.txt
+++ b/malcompiler-test/src/test/resources/analyzer/complex-parser.txt
@@ -94,7 +94,7 @@ categories = {
             cia = {},
             ttc = [],
             meta = {
-              Meta(<complex.mal:26:7>, INFO, "An extra level of protection, their school computer must be used to impersonate them.")
+              Meta(<complex.mal:26:7>, ID(<complex.mal:26:7>, "user"), "An extra level of protection, their school computer must be used to impersonate them.")
             },
             NO_REQUIRES,
             Reaches(<complex.mal:27:7>, OVERRIDES,
@@ -154,7 +154,7 @@ categories = {
             cia = {},
             ttc = [],
             meta = {
-              Meta(<complex.mal:38:7>, INFO, "Retrieval of password is only possible if password is unencrypted")
+              Meta(<complex.mal:38:7>, ID(<complex.mal:38:7>, "user"), "Retrieval of password is only possible if password is unencrypted")
             },
             NO_REQUIRES,
             Reaches(<complex.mal:39:7>, OVERRIDES,

--- a/malcompiler-test/src/test/resources/analyzer/complex.mal
+++ b/malcompiler-test/src/test/resources/analyzer/complex.mal
@@ -23,7 +23,7 @@ category Person {
   asset Student extends User {}
   asset Teacher extends User {
     | accessSchoolComputer
-      info: "An extra level of protection, their school computer must be used to impersonate them."
+      user info: "An extra level of protection, their school computer must be used to impersonate them."
       -> compromise
   }
 }
@@ -35,7 +35,7 @@ category Hardware {
     | interceptTraffic
       -> retrievePassword
     & retrievePassword
-      info: "Retrieval of password is only possible if password is unencrypted"
+      user info: "Retrieval of password is only possible if password is unencrypted"
       -> user.impersonate
     | bypassFirewall [Exponential(0.05) * Gamma(1.2, 1.7)]
       -> firewall.bypassFirewall

--- a/malcompiler-test/src/test/resources/lexer/keywords.txt
+++ b/malcompiler-test/src/test/resources/lexer/keywords.txt
@@ -1,7 +1,5 @@
 include
 info
-assumptions
-rationale
 category
 abstract
 asset

--- a/malcompiler-test/src/test/resources/parser/assets.mal
+++ b/malcompiler-test/src/test/resources/parser/assets.mal
@@ -1,32 +1,32 @@
 category Cat {
   asset A1
-    info: "Info1"
-    rationale: "Reason1"
-    assumptions: "None1"
+    user info: "Info1"
+    developer info: "Reason1"
+    modeler info: "None1"
   {
   }
 
   abstract asset A2
-    info: "Info2"
-    rationale: "Reason2"
-    assumptions: "None2"
+    user info: "Info2"
+    developer info: "Reason2"
+    modeler info: "None2"
   {
     let x = y
   }
 
   asset A3 extends A1
-    info: "Info3"
-    rationale: "Reason3"
-    assumptions: "None3"
+    user info: "Info3"
+    developer info: "Reason3"
+    modeler info: "None3"
   {
     & a
     | a
   }
 
   abstract asset A4 extends A2
-    info: "Info4"
-    rationale: "Reason4"
-    assumptions: "None4"
+    user info: "Info4"
+    developer info: "Reason4"
+    modeler info: "None4"
   {
     # a
     let x = y

--- a/malcompiler-test/src/test/resources/parser/associations.mal
+++ b/malcompiler-test/src/test/resources/parser/associations.mal
@@ -45,7 +45,7 @@ associations {
 associations {
   // With meta
   A1 [b] 1    <-- L --> 1    [a] A2
-     info: "testing"
-     rationale: "hej"
-     assumptions: "\"!\"!\"!\""
+     user info: "testing"
+     developer info: "hej"
+     modeler info: "\"!\"!\"!\""
 }

--- a/malcompiler-test/src/test/resources/parser/attacksteps.mal
+++ b/malcompiler-test/src/test/resources/parser/attacksteps.mal
@@ -34,12 +34,12 @@ category Cat {
   // Testing meta
   asset A3 {
     & a
-      info: "Info"
+      user info: "Info"
     | b
-      info: "Info"
-      rationale: "Reason"
+      user info: "Info"
+      developer info: "Reason"
     # c [TTC]
-      info: "Info"
+      user info: "Info"
   }
 
   // Testing existence
@@ -69,7 +69,7 @@ category Cat {
       <- x
       +> y
     E d {C} [t]
-      info: "Info"
+      user info: "Info"
       <- x
       -> y
   }

--- a/malcompiler-test/src/test/resources/parser/bad-asset4.mal
+++ b/malcompiler-test/src/test/resources/parser/bad-asset4.mal
@@ -1,5 +1,5 @@
 category Cat {
   asset A1 {
-    info: "Info"
+    user info: "Info"
   }
 }

--- a/malcompiler-test/src/test/resources/parser/bad-attackstep4.mal
+++ b/malcompiler-test/src/test/resources/parser/bad-attackstep4.mal
@@ -2,6 +2,6 @@ category Cat {
   asset A1 {
     & a
       ->
-        info: "Info"
+        user info: "Info"
   }
 }

--- a/malcompiler-test/src/test/resources/parser/bad-attackstep5.mal
+++ b/malcompiler-test/src/test/resources/parser/bad-attackstep5.mal
@@ -2,6 +2,6 @@ category Cat {
   asset A1 {
     & a
       <-
-        info: "Info"
+        user info: "Info"
   }
 }

--- a/malcompiler-test/src/test/resources/parser/bad-category1.mal
+++ b/malcompiler-test/src/test/resources/parser/bad-category1.mal
@@ -1,3 +1,3 @@
 category Cat {
-  info: "Info"
+  user info: "Info"
 }

--- a/malcompiler-test/src/test/resources/parser/bad-meta1.mal
+++ b/malcompiler-test/src/test/resources/parser/bad-meta1.mal
@@ -1,4 +1,4 @@
 category Cat
-  information: "Info"
+  user information: "Info"
 {
 }

--- a/malcompiler-test/src/test/resources/parser/bad-meta2.mal
+++ b/malcompiler-test/src/test/resources/parser/bad-meta2.mal
@@ -1,4 +1,4 @@
 category Cat
-  info = "Info"
+  user info = "Info"
 {
 }

--- a/malcompiler-test/src/test/resources/parser/bad-meta3.mal
+++ b/malcompiler-test/src/test/resources/parser/bad-meta3.mal
@@ -1,4 +1,4 @@
 category Cat
-  info: Info
+  user info: Info
 {
 }

--- a/malcompiler-test/src/test/resources/parser/categories.mal
+++ b/malcompiler-test/src/test/resources/parser/categories.mal
@@ -4,17 +4,17 @@ category C1 {
 }
 
 category C2
-  assumptions: "none"
+  modeler info: "none"
 {
   asset A3 extends A1 { }
   abstract asset A4 extends A2 { }
 }
 
 category C3
-  info: "this is first C3"
-  info: "another info"
-  rationale: "just to test"
-  assumptions: "will not run through the analyzer"
+  user info: "this is first C3"
+  user info: "another info"
+  developer info: "just to test"
+  modeler info: "will not run through the analyzer"
 {
 }
 

--- a/malcompiler-test/src/test/resources/parser/to-string.ans
+++ b/malcompiler-test/src/test/resources/parser/to-string.ans
@@ -5,7 +5,7 @@ defines = {
 categories = {
   Category(<to-string.mal:3:10>, ID(<to-string.mal:3:19>, "CAT"),
     meta = {
-      Meta(<to-string.mal:4:12>, INFO, "meta")
+      Meta(<to-string.mal:4:12>, ID(<to-string.mal:4:12>, "user"), "meta")
     },
     assets = {
       Asset(<to-string.mal:5:13>, NOT_ABSTRACT, ID(<to-string.mal:5:19>, "A1"), PARENT(ID(<to-string.mal:5:30>, "A1")),
@@ -18,7 +18,7 @@ categories = {
       ),
       Asset(<to-string.mal:7:13>, ABSTRACT, ID(<to-string.mal:7:28>, "A2"), NO_PARENT,
         meta = {
-          Meta(<to-string.mal:8:15>, INFO, "info")
+          Meta(<to-string.mal:8:15>, ID(<to-string.mal:8:15>, "user"), "info")
         },
         attacksteps = {
           AttackStep(<to-string.mal:9:15>, ALL, ID(<to-string.mal:9:17>, "at"),
@@ -47,7 +47,7 @@ categories = {
             cia = {},
             ttc = [TTCFuncExpr(<to-string.mal:12:22>, ID(<to-string.mal:12:22>, "a"))],
             meta = {
-              Meta(<to-string.mal:13:17>, INFO, "at2")
+              Meta(<to-string.mal:13:17>, ID(<to-string.mal:13:17>, "user"), "at2")
             },
             NO_REQUIRES,
             Reaches(<to-string.mal:14:17>, INHERITS,
@@ -70,13 +70,13 @@ categories = {
 associations = {
   Association(<to-string.mal:22:5>, ID(<to-string.mal:22:5>, "A1"), ID(<to-string.mal:22:9>, "a"), ZERO_OR_ONE, ID(<to-string.mal:22:21>, "L"), ONE_OR_MORE, ID(<to-string.mal:22:33>, "b"), ID(<to-string.mal:22:36>, "A2"),
     meta = {
-      Meta(<to-string.mal:23:8>, INFO, "Info")
+      Meta(<to-string.mal:23:8>, ID(<to-string.mal:23:8>, "user"), "Info")
     }
   ),
   Association(<to-string.mal:24:5>, ID(<to-string.mal:24:5>, "A2"), ID(<to-string.mal:24:9>, "b"), ZERO_OR_MORE, ID(<to-string.mal:24:21>, "L"), ZERO_OR_MORE, ID(<to-string.mal:24:33>, "a"), ID(<to-string.mal:24:36>, "A1"),
     meta = {
-      Meta(<to-string.mal:25:8>, INFO, "info"),
-      Meta(<to-string.mal:26:8>, INFO, "info2")
+      Meta(<to-string.mal:25:8>, ID(<to-string.mal:25:8>, "user"), "info"),
+      Meta(<to-string.mal:26:8>, ID(<to-string.mal:26:8>, "user"), "info2")
     }
   ),
   Association(<to-string.mal:27:5>, ID(<to-string.mal:27:5>, "A1"), ID(<to-string.mal:27:9>, "a"), ONE, ID(<to-string.mal:27:21>, "L"), ONE, ID(<to-string.mal:27:33>, "b"), ID(<to-string.mal:27:36>, "A2"),

--- a/malcompiler-test/src/test/resources/parser/to-string.mal
+++ b/malcompiler-test/src/test/resources/parser/to-string.mal
@@ -1,16 +1,16 @@
 #hej: "hej"
 
          category CAT
-           info: "meta" {
+           user info: "meta" {
             asset A1 extends A1 {
             }
             abstract asset A2
-              info: "info" {
+              user info: "info" {
               & at
                 <- a
                 -> a
               | at2 [a]
-                info: "at2"
+                user info: "at2"
                 +> a, b
               let b = a
             }
@@ -20,9 +20,9 @@
 
   associations {
     A1 [a] 0..1 <-- L --> 1..* [b] A2
-       info: "Info"
+       user info: "Info"
     A2 [b] 0..* <-- L --> *    [a] A1
-       info: "info"
-       info: "info2"
+       user info: "info"
+       user info: "info2"
     A1 [a] 1    <-- L --> 1..1 [b] A2
   }

--- a/malcompiler-test/src/test/resources/vehiclelang/vehicleLang.mal
+++ b/malcompiler-test/src/test/resources/vehiclelang/vehicleLang.mal
@@ -14,127 +14,127 @@ include "vehicleLangPublicInterfaces.mal"
 category System {
     
     abstract asset PhysicalMachine
-        info: "Specifies any physical machine."
+        user info: "Specifies any physical machine."
     {
         | connect
-                info: "Connect leads directly to access on a physical machine since no authentication is done/needed."
+                user info: "Connect leads directly to access on a physical machine since no authentication is done/needed."
                 ->  access
 
         | access
-                rationale: "This is empty in order to be overriden."
+                developer info: "This is empty in order to be overriden."
     }
 
     asset SensorOrActuator extends PhysicalMachine
-        info: "Specifies physical machines like sensors and actuators."
+        user info: "Specifies physical machines like sensors and actuators."
     {
         | connect
-                info: "Connect leads directly to access on a physical machine since no authentication is done/needed."
+                user info: "Connect leads directly to access on a physical machine since no authentication is done/needed."
                 ->  access
 
         | access
-                info: "Access means that the attacker has full access on the machine, ex. he can manipulate the actuator's behavior or sensor's measurements."
+                user info: "Access means that the attacker has full access on the machine, ex. he can manipulate the actuator's behavior or sensor's measurements."
                 ->  manipulate
 
         | manipulate
-                rationale: "This is empty for now because it is enough to reach this."
+                developer info: "This is empty for now because it is enough to reach this."
     }
 
     asset Machine extends PhysicalMachine
-        info: "Specifies any machine that has higher complexity than a simple actuator or sensor."
+        user info: "Specifies any machine that has higher complexity than a simple actuator or sensor."
     {
 
         | connect
-                info: "Attempt to connect to a machine."
+                user info: "Attempt to connect to a machine."
                 ->	authenticatedAccess,
                     connectPrivileges.compromise,
                     connectionVulnerabilities.exploit
 
         | authenticate
-                info: "Does the attacker have the credentials of an account?"
+                user info: "Does the attacker have the credentials of an account?"
                 ->	authenticatedAccess
 
         & authenticatedAccess
-                  info: "One way to gain access to a machine is through legitimate authentication."
+                  user info: "One way to gain access to a machine is through legitimate authentication."
                 ->	access
 
         | bypassAccessControl
-                info: "An attacker can bypass access control and authenticate immediately to the machine."
+                user info: "An attacker can bypass access control and authenticate immediately to the machine."
                 -> access
 
         | access
-                rationale: "We don't explicitly model root access; that is not a sound primitive. Instead, such an account can be modelled explicitly by providing an account with access to all executees and all data."
+                developer info: "We don't explicitly model root access; that is not a sound primitive. Instead, such an account can be modelled explicitly by providing an account with access to all executees and all data."
                 ->	_machineAccess
 
         | idAccess
-                info: "This is used when ID is compromised from data."
+                user info: "This is used when ID is compromised from data."
 
         | _machineAccess
-                rationale: "Again, this is a helper attack step that will also be used from the childs of this asset."
+                developer info: "Again, this is a helper attack step that will also be used from the childs of this asset."
                 ->	denialOfService,
                     _accessData,
                     executees.connect,
                     accessVulnerabilities.exploit
 
         | denialOfService
-                info: "Perform a DoS attack on the machine."
+                user info: "Perform a DoS attack on the machine."
                 ->	executees.denialOfService,
                     data.denyAccess
 
         | _accessData
-                info: "A helper attack step to reach request access on data stored on a machine"
+                user info: "A helper attack step to reach request access on data stored on a machine"
                 ->  data.requestAccess
 
         | passFirmwareValidation
-                rationale: "Again, this is a blank helper attack step that will also be used from the childs of this asset."
+                developer info: "Again, this is a blank helper attack step that will also be used from the childs of this asset."
 
         | udsFirmwareModification
-                rationale: "This is a blank helper attack step that should be reached from FirmwareUpdaterService."
+                developer info: "This is a blank helper attack step that should be reached from FirmwareUpdaterService."
 
         | passUdsFirmwareModification
-                rationale: "This is a blank helper attack step that should be reached from FirmwareUpdaterService."
+                developer info: "This is a blank helper attack step that should be reached from FirmwareUpdaterService."
 
         | gainNetworkAccess
-                info: "This attack step will be only implemented on the infotainment system asset."
+                user info: "This attack step will be only implemented on the infotainment system asset."
     }
 
     asset ECU extends Machine
-        info: "Specifies any ECU/MCU/controller in a vehicle."
-        rationale: "Created as new parent class because the existing Machine had many unrelated attacks."
+        user info: "Specifies any ECU/MCU/controller in a vehicle."
+        developer info: "Created as new parent class because the existing Machine had many unrelated attacks."
     {
         | connect
-                info: "Attackers can attempt to connect to the ECU and change the operation mode if they have access to the network, services, dataflows, etc..."
+                user info: "Attackers can attempt to connect to the ECU and change the operation mode if they have access to the network, services, dataflows, etc..."
                 +>  attemptChangeOperationMode
                     //firmwareUpdater.connect
 
         | maliciousFirmwareUpload
-                info: "Maliciously upload a forged firmware leads to full access on the ECU and ability to inject messages on the previous running services."
+                user info: "Maliciously upload a forged firmware leads to full access on the ECU and ability to inject messages on the previous running services."
                 ->  access,
                     _firmwareUploadNetworkAccess
 
         & uploadFirmware
-                info: "Updating the firmware leads to the ability to inject messages not only on the previous running services but also on network. Additionaly it leads to J1939 attacks."
+                user info: "Updating the firmware leads to the ability to inject messages not only on the previous running services but also on network. Additionaly it leads to J1939 attacks."
                 ->  _firmwareUploadNetworkAccess
 
         | _firmwareUploadNetworkAccess
-                info: "This a helper attack step because both above attack steps are leading to the same connections."
+                user info: "This a helper attack step because both above attack steps are leading to the same connections."
                 ->  vehiclenetworks.messageInjection, // NOTE: I still think this is needed here, blame me!
                     vehiclenetworks.j1939Attacks,
                     vehiclenetworks._networkForwarding // This is left here because it might be needed! Or it might not...
 
         | udsFirmwareModification
-                info: "This attack step is reached after access on FirmwareUpdaterService."
+                user info: "This attack step is reached after access on FirmwareUpdaterService."
                 ->  firmwareUpdater.udsFirmwareUpload
 
         | passUdsFirmwareModification
-                info: "Same as below, if the cryptographic key is accessed."
+                user info: "Same as below, if the cryptographic key is accessed."
                 ->  firmwareUpdater.passUdsFirmwareUpload
 
         | passFirmwareValidation
-                info: "If the firmware validation key is stored in the ECU, this means that the firmware validation is passed and a new firmware can be uploaded."
+                user info: "If the firmware validation key is stored in the ECU, this means that the firmware validation is passed and a new firmware can be uploaded."
                 ->  uploadFirmware
 
         | access
-                info: "Attackers have access to the ECU if they have compromised its firmware (after custom firmware upload), bypassed access control (after authentication via diagnostics) or properly authenticated themselves."
+                user info: "Attackers have access to the ECU if they have compromised its firmware (after custom firmware upload), bypassed access control (after authentication via diagnostics) or properly authenticated themselves."
                 +>	sensorsOrActuators.manipulate,
                     changeOperationMode,
                     gainLINAccessFromCAN,
@@ -142,55 +142,55 @@ category System {
                     vehiclenetworks.access
 
         | idAccess
-                info: "This attack step is reached after the ID is compromised from data and allows an attacker to connect to the connected physical machines."
+                user info: "This attack step is reached after the ID is compromised from data and allows an attacker to connect to the connected physical machines."
                 ->  _machineAccess,
                     sensorsOrActuators.manipulate
 
         | offline
-                info: "When the ECU is taken offline by some other attack step. Offline means that the ECU is still powered on but unable to communicate on its bus. The effort needed to achieve this is applied on the distributions of the parent attacks."
+                user info: "When the ECU is taken offline by some other attack step. Offline means that the ECU is still powered on but unable to communicate on its bus. The effort needed to achieve this is applied on the distributions of the parent attacks."
                 ->	denialOfService,
                     bypassMessageConfliction
 
         | shutdown
-                info: "When the ECU is powered off by some other attack step. The effort needed to achieve this is applied on the distributions of the parent attacks."
+                user info: "When the ECU is powered off by some other attack step. The effort needed to achieve this is applied on the distributions of the parent attacks."
                 ->	bypassMessageConfliction,
                     denialOfService // Deny access to data and executees
 
         & changeOperationMode
-                info: "Put the ECU into diagnostics (if vehicle is moving slowly or is stopped) or even update mode (bootmode). Leads to shutdown since attacker must have achieved access on this ECU to reach this step."
+                user info: "Put the ECU into diagnostics (if vehicle is moving slowly or is stopped) or even update mode (bootmode). Leads to shutdown since attacker must have achieved access on this ECU to reach this step."
                 // This can bypass message conflictions and IDPS because the legitimate ECU will no lorger send messages and the attacker can imitate it, if carefull.
                 -> 	shutdown,
                     firmware.maliciousFirmwareModification,
                     uploadFirmware
 
         & attemptChangeOperationMode [Exponential(10.0)]
-                info: "Put the ECU into diagnostics (if vehicle is moving slowly or is stopped) or even update mode (bootmode) but after some effort. This stops ECU from communicating on its bus -> offline"
+                user info: "Put the ECU into diagnostics (if vehicle is moving slowly or is stopped) or even update mode (bootmode) but after some effort. This stops ECU from communicating on its bus -> offline"
                 -> 	offline,
                     bypassMessageConfliction,
                     firmware.maliciousFirmwareModification
 
         # operationModeProtection
-                info: "Either prevent diagnostics mode after vehicles starts moving or allow diagnostics mode only after some physical change is done on vehicle."
-                rationale: "Charlie Miller and Chris Valasek, CAN message injection (2016)."
+                user info: "Either prevent diagnostics mode after vehicles starts moving or allow diagnostics mode only after some physical change is done on vehicle."
+                developer info: "Charlie Miller and Chris Valasek, CAN message injection (2016)."
                 ->	changeOperationMode,
                     attemptChangeOperationMode
 
         | bypassMessageConfliction
-                info: "Bypass message confliction protection mechanisms by changing ECU's operation mode -> no conflicts -> service message injection."
+                user info: "Bypass message confliction protection mechanisms by changing ECU's operation mode -> no conflicts -> service message injection."
                 ->	executees.serviceMessageInjection
 
         & _networkServiceMessageInjection
-                info: "Inject forged service messages that could notify about vehicle’s fault or report fake status (speed, operation mode, etc.). This can even lead to unresponsive ECU (TPMS). This is reached from network access."
+                user info: "Inject forged service messages that could notify about vehicle’s fault or report fake status (speed, operation mode, etc.). This can even lead to unresponsive ECU (TPMS). This is reached from network access."
                 ->	executees.serviceMessageInjection
 
         # messageConflictionProtection
-                info: "Defend against message injection by using message confliction mechanisms (detect messages with own ID). This acts like a host-based IDS."
-                rationale: "Pierre Kleberger, Tomas Olovsson, and Erland Jonsson, Security Aspects of the In-Vehicle Network in the Connected Car (2011)."
+                user info: "Defend against message injection by using message confliction mechanisms (detect messages with own ID). This acts like a host-based IDS."
+                developer info: "Pierre Kleberger, Tomas Olovsson, and Erland Jonsson, Security Aspects of the In-Vehicle Network in the Connected Car (2011)."
                 ->	_networkServiceMessageInjection
 
         | gainLINAccessFromCAN
-                info: "There are techniques that make it easy to gain access to the LIN bus through a CAN-bus node."
-                rationale: "Junko Takahashi et al., Automotive Attacks and Countermeasures on LIN-Bus (2017)"
+                user info: "There are techniques that make it easy to gain access to the LIN bus through a CAN-bus node."
+                developer info: "Junko Takahashi et al., Automotive Attacks and Countermeasures on LIN-Bus (2017)"
                 //  NOTE: This should happen only with a probability and not always.
                 ->	vehiclenetworks.gainLINAccessFromCAN //NOTE: A solution for this must be found!!!
 
@@ -202,49 +202,49 @@ category System {
     }
 
     asset GatewayECU extends ECU
-        info: "Specifies the ECU that acts as a gateway/firewall on a vehicle."
+        user info: "Specifies the ECU that acts as a gateway/firewall on a vehicle."
     {
         | access
-                rationale: "Overriding from ECU"
+                developer info: "Overriding from ECU"
                 +>	trafficVNetworks.manInTheMiddle, // This will act as Firewall and IDPS are disabled!
                     forwarding
 
         | forwarding
-                rationale: "Forwarding is the lightest interaction with the gateway, where the gateway simply retransmits received messages. Vulnerabilities may, however, lead to compromise of the gateway as well as of the associated firewall. Therefore, Forwarding leads to Connect."
+                developer info: "Forwarding is the lightest interaction with the gateway, where the gateway simply retransmits received messages. Vulnerabilities may, however, lead to compromise of the gateway as well as of the associated firewall. Therefore, Forwarding leads to Connect."
                 -> 	connect,
                     bypassFirewall  // If firewall is not enabled then bypass it.
 
         & bypassFirewall
-                info: "If firewall is disabled, then attacker can bypass it."
+                user info: "If firewall is disabled, then attacker can bypass it."
                 ->	gatewayBypassIDPS, // Added here to stop those attacks when firewall is enabled.
                     gatewayNoIDPS,
                     trafficVNetworks.accessUDSservices
 
         # firewallProtection // Firewall is just a defense on gateway ECU.
-                info: "Firewall protection comes from the existence of a correctly configured firewall."
+                user info: "Firewall protection comes from the existence of a correctly configured firewall."
                 -> bypassFirewall
 
         | denialOfService
-                info: "Perform denial of service attack on the connected networks."
+                user info: "Perform denial of service attack on the connected networks."
                 -> 	trafficVNetworks.denialOfService
 
         // IDPS is modeled as a centralized inline IDPS
         E idpsExists
-                info: "Check for the existence of an IDPS."
+                user info: "Check for the existence of an IDPS."
                 <- idps
                 -> gatewayBypassIDPS
 
         & gatewayBypassIDPS
-                info: "Bypass IDPS protection when IDPS is in place, but only if firewall is disabled."
+                user info: "Bypass IDPS protection when IDPS is in place, but only if firewall is disabled."
                 -> trafficVNetworks._bypassIDPS
 
         !E idpsDoesNotExist
-                info: "Check for the non existence of an IDPS."
+                user info: "Check for the non existence of an IDPS."
                 <-	idps
                 ->	gatewayNoIDPS
 
         & gatewayNoIDPS
-                info: "IDPS is disabled so the attacker can access the network unrestricted, but only if firewall is also disabled."
+                user info: "IDPS is disabled so the attacker can access the network unrestricted, but only if firewall is also disabled."
                 -> trafficVNetworks._noIDPS,
                    trafficVNetworks.accessNetworkLayer // Moved it here from forwarding to allow imediate network access only if idps does not exist.
     }
@@ -252,47 +252,47 @@ category System {
     asset Software extends Machine 
     {
         | access
-                info: "Get access to the software."
+                user info: "Get access to the software."
                 +>	executor.connect,
                     assignedAccounts.authenticate
 
         | serviceMessageInjection
-                rationale: "This is an empty attack step that will only be used from the childs of this asset."
+                developer info: "This is an empty attack step that will only be used from the childs of this asset."
     }
 
     asset Firmware extends Software
-        info: "Specifies the firmware running on an ECU as a software."
+        user info: "Specifies the firmware running on an ECU as a software."
     {
         | maliciousFirmwareModification
-                info: "Perform a firmware update either by cracking Secure Boot or worse by exploiting the absence of it."
+                user info: "Perform a firmware update either by cracking Secure Boot or worse by exploiting the absence of it."
                 ->  bypassSecureBoot,
                     crackSecureBoot
 
         & crackFirmwareValidation [Exponential(20.0)]
-                info: "Crack firmware validation if it is enabled."
+                user info: "Crack firmware validation if it is enabled."
                 ->  hardware.maliciousFirmwareUpload
 
         & bypassFirmwareValidation
-                info: "Bypass firmware validation if it is not enabled."
+                user info: "Bypass firmware validation if it is not enabled."
                 ->  hardware.maliciousFirmwareUpload
 
         # firmwareValidation
-                info: "Code signing and verification during upload, use of strong checksum functions and/or don’t distribute the private keys for signing."
-                rationale: "Rubicon - Zero-knowledge Armor for Automotive Security, RubiconLabs"
+                user info: "Code signing and verification during upload, use of strong checksum functions and/or don’t distribute the private keys for signing."
+                developer info: "Rubicon - Zero-knowledge Armor for Automotive Security, RubiconLabs"
                 ->	bypassFirmwareValidation
 
         & bypassSecureBoot
-                info: "Bypass Secure Boot if it is not enabled Then validate a firmware update either by cracking (brute forcing) the checksum or worse by exploiting the absence of verification."
+                user info: "Bypass Secure Boot if it is not enabled Then validate a firmware update either by cracking (brute forcing) the checksum or worse by exploiting the absence of verification."
                 ->  bypassFirmwareValidation,
                     crackFirmwareValidation
 
         | crackSecureBoot [Exponential(50.0)]
-                info: "Crack Secure Boot if it is enabled is hard"
+                user info: "Crack Secure Boot if it is enabled is hard"
                 ->  hardware.maliciousFirmwareUpload
 
         # secureBoot
-                info: "SecureBoot is a protection mechanism that which validates the boot software and not the firmware at system boot time."
-                rationale: "SecureBoot should make running of forged firmware even harder when enabled. Threfore it stops firmware validation attack steps."
+                user info: "SecureBoot is a protection mechanism that which validates the boot software and not the firmware at system boot time."
+                developer info: "SecureBoot should make running of forged firmware even harder when enabled. Threfore it stops firmware validation attack steps."
                 ->  bypassSecureBoot
     }
 
@@ -313,65 +313,65 @@ category System {
     }
 
     asset NetworkClient extends Client
-        info: "Represents a client connected to a service running on a network."
+        user info: "Represents a client connected to a service running on a network."
     {
         | access
                 +>	dataflows.request
     }
 
     asset VehicleNetworkReceiver extends Client
-        info: "Represents a receiver/client for connectionless dataflows connected to a transmitter running on a vehicle network."
+        user info: "Represents a receiver/client for connectionless dataflows connected to a transmitter running on a vehicle network."
     {
         | access
                 +>	dataflows.eavesdrop
     }
 
     asset NetworkService extends Service
-        info: "Represents a service running on top of a network."
+        user info: "Represents a service running on top of a network."
     {
         | access
                 +>	dataflows.respond
     }
 
     asset UDSService extends NetworkService
-        info: "Represents an ISO 14229 - Unified Diagnostics Service (UDS) running on an ECU."
-        rationale: "Pierre Kleberger, On Securing the Connected Car: Methods and Protocols for Secure Vehicle Diagnostics, PhD Thesis (2015)"
+        user info: "Represents an ISO 14229 - Unified Diagnostics Service (UDS) running on an ECU."
+        developer info: "Pierre Kleberger, On Securing the Connected Car: Methods and Protocols for Secure Vehicle Diagnostics, PhD Thesis (2015)"
     {
         | access
-                info: "Access on an UDS service provides access on stored data, possibility to update firmware and change operation status of the ECU."
+                user info: "Access on an UDS service provides access on stored data, possibility to update firmware and change operation status of the ECU."
                 +>	dataflows.respond,
                     executor._accessData
     }
 
     asset TransmitterService extends Service
-        info: "Represents a service/transmitter running on an ECU and on top of a vehicle network."
+        user info: "Represents a service/transmitter running on an ECU and on top of a vehicle network."
     {
         | access
                 +>	dataflows.transmit,
                     dataflows.denialOfService // This is only possible here because only one Transmitter can be connected to a conectionless dataflow
 
         | serviceMessageInjection
-                info: "Tamper dataflows that are conneceted to this network transmitter after bypassing message confliction on the ECU."
+                user info: "Tamper dataflows that are conneceted to this network transmitter after bypassing message confliction on the ECU."
                 ->	dataflows.maliciousTransmit
     }
 
     asset FirmwareUpdaterService extends UDSService
-        info:"Specifies the firmware updating procedure/UDS service on an ECU."
+        user info:"Specifies the firmware updating procedure/UDS service on an ECU."
     {
         | access
                 +>  firmwareTarget.udsFirmwareModification
 
         & udsFirmwareUpload
-                info: "If UDS Security Access defense is disabled, attacker can maliciously upload firmware."
+                user info: "If UDS Security Access defense is disabled, attacker can maliciously upload firmware."
                 ->  firmwareTarget.maliciousFirmwareUpload
 
         | passUdsFirmwareUpload
-                info: "If the cryptographic key of Security Access is read then, the firmware upload procedure can easily be initiated."
+                user info: "If the cryptographic key of Security Access is read then, the firmware upload procedure can easily be initiated."
                 ->  firmwareTarget.passFirmwareValidation
 
         # udsSecurityAccess
-                info: "Firmware upload via UDS is protected by a UDS service called Security Access. This is an authentication protocol which uses a challenge-response scheme with cryptographic keys."
-                rationale: "Interview with domain experts conducted by Nedo"
+                user info: "Firmware upload via UDS is protected by a UDS service called Security Access. This is an authentication protocol which uses a challenge-response scheme with cryptographic keys."
+                developer info: "Interview with domain experts conducted by Nedo"
                 ->  udsFirmwareUpload
     }
 
@@ -380,55 +380,55 @@ category System {
 category Networking {
 
     asset Network
-        info: "Networks include Ethernet LANs, vehicle networks, the Internet, and Wifi networks."
+        user info: "Networks include Ethernet LANs, vehicle networks, the Internet, and Wifi networks."
     {
         | physicalAccess
-                info: "Physical access to the network."
+                user info: "Physical access to the network."
                 ->	accessNetworkLayer
 
         | access
-                info: "Access implies the possibility to submit packets over the network. In a generic network, it does not imply the possibility to listen to others' traffic on the network. You are outside the router but with a possibility to communicate in to the network."
+                user info: "Access implies the possibility to submit packets over the network. In a generic network, it does not imply the possibility to listen to others' traffic on the network. You are outside the router but with a possibility to communicate in to the network."
                 ->	denialOfService,
                     networkMachines[NetworkService].connect,
                     networkMachines.connect
 
         | accessNetworkLayer
-                info: "Access on the network later implies the possibility to submit packets over the network and the possibility to listen to others' traffic on the network."
+                user info: "Access on the network later implies the possibility to submit packets over the network and the possibility to listen to others' traffic on the network."
                 ->	denialOfService,
                     networkMachines[NetworkService].connect,
                     eavesdrop
 
         | eavesdrop
-                info: "Attackers can sometimes eavesdrop."
+                user info: "Attackers can sometimes eavesdrop."
                 -> 	dataflows.eavesdrop
 
         | manInTheMiddle
-                    info: "Attackers can sometimes intercept and tamper with communications."
+                    user info: "Attackers can sometimes intercept and tamper with communications."
                 -> 	access,
                     eavesdrop,
                     dataflows.manInTheMiddle
 
         | denialOfService
-                info: "The network is made unavailable."
+                user info: "The network is made unavailable."
                 -> 	dataflows.denialOfService
     }
 
     asset VehicleNetwork extends Network
-        info: "Vehicle Networks include CAN bus, FlexRay and LIN bus."
+        user info: "Vehicle Networks include CAN bus, FlexRay and LIN bus."
     {
         | _networkSpecificAttack
-                info: "This attack step should work as an intermediate step to reach network specific attacks."
+                user info: "This attack step should work as an intermediate step to reach network specific attacks."
 
         | access
-                info: "Access implies the possibility to submit packets over the network. In a generic network, it does not imply the possibility to listen to others' traffic on the network. You are outside the router but with a possibility to communicate in to the network."
-                rationale: "Overriding from network"
+                user info: "Access implies the possibility to submit packets over the network. In a generic network, it does not imply the possibility to listen to others' traffic on the network. You are outside the router but with a possibility to communicate in to the network."
+                developer info: "Overriding from network"
                 ->	denialOfService,
                     networkMachines[NetworkService].connect,
                     networkECUs.connect // Reach ECUs connected network and try to connect, not access!
 
         | accessNetworkLayer
-                info: "Network layer access implies the possibility to submit messages over the network and the possibility to listen to others' traffic on the network."
-                rationale: "Overriding from network"
+                user info: "Network layer access implies the possibility to submit messages over the network and the possibility to listen to others' traffic on the network."
+                developer info: "Overriding from network"
                 ->	access,
                     _networkForwarding,
                     eavesdrop,
@@ -438,12 +438,12 @@ category Networking {
                     networkECUs._networkServiceMessageInjection // This is for the case where the message confliction is disabled but attacking from the network.
 
         | _networkForwarding
-                info: "An attacker that has access to a network connected ECU can also perform forwarding on that network using the connected GatewayECU. (helper attack)"
+                user info: "An attacker that has access to a network connected ECU can also perform forwarding on that network using the connected GatewayECU. (helper attack)"
                 -> trafficGatewayECU.forwarding
 
         // Override
         | manInTheMiddle
-                info: "This attack is reached only as an attacker's entry point or from GatewayEcu.access. It leads, among others, to dataflows MitM."
+                user info: "This attack is reached only as an attacker's entry point or from GatewayEcu.access. It leads, among others, to dataflows MitM."
                 ->	accessNetworkLayer,
                     eavesdrop,
                     dataflows.manInTheMiddle,
@@ -451,164 +451,164 @@ category Networking {
         // This will require, by default, some effort especially for maliciousRespond, because message conflictions mechanisms are by default enabled.
         // This attack is only reached as an entry point or from GatewayEcu.access, also see serviceMessageInjection.
         | messageInjection
-                info: "Inject messages to dataflows means that attacker can try to transmit messages on the vehicle network but might not be sucessful because of the message confliction protection. That could notify about vehicle’s fault or report fake status (speed, operation mode, etc.)."
+                user info: "Inject messages to dataflows means that attacker can try to transmit messages on the vehicle network but might not be sucessful because of the message confliction protection. That could notify about vehicle’s fault or report fake status (speed, operation mode, etc.)."
                 ->	dataflows.maliciousTransmitBypassConflitionProtection
 
         | _bypassIDPS
-                info: "Bypass IDPS on dataflows when the GatewayECU has IDPS enabled. (helper attack)"
+                user info: "Bypass IDPS on dataflows when the GatewayECU has IDPS enabled. (helper attack)"
                 ->	dataflows.maliciousTransmitBypassIDPS
 
         | _noIDPS
-                info: "When no IDPS is connected/present on the GatewayECU. (helper attack)"
+                user info: "When no IDPS is connected/present on the GatewayECU. (helper attack)"
                 ->	dataflows.maliciousTransmitNoIDPS
 
         | gainLINAccessFromCAN
-                rationale: "This is an empty attack that will only be implemented on LINNetwork and it will be invoked by the ECU."
+                developer info: "This is an empty attack that will only be implemented on LINNetwork and it will be invoked by the ECU."
 
         | j1939Attacks
-                info: "This is an empty attack that will only be implemented on J1939Network and it will be invoked by the ECU or by having network access."
-                rationale: "Yelizaveta Burakova, Bill Hass, Leif Millar, and Andre Weimerskirch, Truck Hacking: An Experimental Analysis of the SAE J1939 Standard (2016)"
+                user info: "This is an empty attack that will only be implemented on J1939Network and it will be invoked by the ECU or by having network access."
+                developer info: "Yelizaveta Burakova, Bill Hass, Leif Millar, and Andre Weimerskirch, Truck Hacking: An Experimental Analysis of the SAE J1939 Standard (2016)"
 
         | accessUDSservices
                 ->  networkFwUpdater.access
     }
 
     asset CANNetwork extends VehicleNetwork
-        info: "Represents the CAN bus network and the attacks that are possible on it."
+        user info: "Represents the CAN bus network and the attacks that are possible on it."
     {
         | _networkSpecificAttack
-                info: "This attack step should work as an intermediate step to reach network specific attacks."
+                user info: "This attack step should work as an intermediate step to reach network specific attacks."
                 ->	busOffAttack,
                     exploitArbitration
 
         | exploitArbitration [Exponential(10.0)]
-                info: "Exploiting the arbitration mechanism for message prioritization in CAN bus can lead to invalidation of legitimate messages/DoS and allow message tampering/injection."
-                rationale: "Charlie Miller and Chris Valasek, 'Jeep Hack' & Pal-Stefan Murvay and Bogdan Groza, Security shortcomings and countermeasures for the SAE J1939 commercial vehicle bus protocol (2017)"
+                user info: "Exploiting the arbitration mechanism for message prioritization in CAN bus can lead to invalidation of legitimate messages/DoS and allow message tampering/injection."
+                developer info: "Charlie Miller and Chris Valasek, 'Jeep Hack' & Pal-Stefan Murvay and Bogdan Groza, Security shortcomings and countermeasures for the SAE J1939 commercial vehicle bus protocol (2017)"
                 ->	dataflows.maliciousTransmit, // This is different from the messageInjection attack because, if successful, allows direct malicious respond and request.
                     denialOfService
 
         & busOffAttack [Exponential(1.0)]
-                info: "Exploits the error-handling scheme of in-vehicle networks to disconnect good/uncompromised ECUs or cause DoS on the entire network. This is an easy to mount attack. This is also applicable on CAN-FD."
-                rationale: "Kyong-Tak Cho and Kang G. Shin, Error Handling of In-vehicle Networks Makes Them Vulnerable (2016)"
+                user info: "Exploits the error-handling scheme of in-vehicle networks to disconnect good/uncompromised ECUs or cause DoS on the entire network. This is an easy to mount attack. This is also applicable on CAN-FD."
+                developer info: "Kyong-Tak Cho and Kang G. Shin, Error Handling of In-vehicle Networks Makes Them Vulnerable (2016)"
                 ->	networkECUs.offline,
                     denialOfService
 
         # busOffProtection
-                info: "Based on the defence mechanism proposed by the related paper"
-                rationale: "Kyong-Tak Cho and Kang G. Shin, Error Handling of In-vehicle Networks Makes Them Vulnerable (2016)"
+                user info: "Based on the defence mechanism proposed by the related paper"
+                developer info: "Kyong-Tak Cho and Kang G. Shin, Error Handling of In-vehicle Networks Makes Them Vulnerable (2016)"
                 ->	busOffAttack
     }
 
     asset J1939Network extends CANNetwork
-        info: "SAE J1939 is a CAN-based protocol employed in many heavy duty vehicles."
+        user info: "SAE J1939 is a CAN-based protocol employed in many heavy duty vehicles."
     {
         // Override
         | accessNetworkLayer
-                info: "Network layer access implies the possibility to submit messages over the network. It does not imply the possibility to listen to others' trafic on the network."
+                user info: "Network layer access implies the possibility to submit messages over the network. It does not imply the possibility to listen to others' trafic on the network."
                 ->	denialOfService,
                     eavesdrop,
                     messageInjection,
                     networkECUs.connect
 
         | eavesdrop
-                info: "An attacker can eavesdrop/sniff the network."
-                rationale: "Luca Dariz, Massimiliano Ruggeri, Gianpiero Costantino and Fabio Martinelli, A Survey over Low-Level Security Issues in Heavy Duty Vehicles (2016)"
+                user info: "An attacker can eavesdrop/sniff the network."
+                developer info: "Luca Dariz, Massimiliano Ruggeri, Gianpiero Costantino and Fabio Martinelli, A Survey over Low-Level Security Issues in Heavy Duty Vehicles (2016)"
                 -> 	j1939dataflows.eavesdrop
 
         | manInTheMiddle
-                    info: "Attackers can sometimes intercept and tamper with communications."
+                    user info: "Attackers can sometimes intercept and tamper with communications."
                 -> 	accessNetworkLayer,
                     eavesdrop,
                     j1939dataflows.manInTheMiddle
 
         | denialOfService
-                info: "A DoS attack can happen on a J1939 network with three possible ways as described on the paper below."
-                rationale: "Subhojeet Mukherjee et al., Practical DoS Attacks on Embedded Networks in Commercial Vehicles (2016)"
+                user info: "A DoS attack can happen on a J1939 network with three possible ways as described on the paper below."
+                developer info: "Subhojeet Mukherjee et al., Practical DoS Attacks on Embedded Networks in Commercial Vehicles (2016)"
                 -> 	j1939dataflows.denialOfService
 
         | messageInjection
-                rationale: "Overriding from parent because in this type of networks, messageInjection should not happen with the same way."
+                developer info: "Overriding from parent because in this type of networks, messageInjection should not happen with the same way."
 
         | j1939MessageInjection
-                info: "Inject messages to J1939 means that attacker can make requests towards other J1939 nodes or PGNs (Parameter Group Number) and after effort to maliciously respond."
+                user info: "Inject messages to J1939 means that attacker can make requests towards other J1939 nodes or PGNs (Parameter Group Number) and after effort to maliciously respond."
                 ->	j1939dataflows.request,
                     j1939dataflows.maliciousRespond
 
         | j1939Attacks
-                info: "This attack step should work as an intermediate step to reach J1939 network specific attacks."
+                user info: "This attack step should work as an intermediate step to reach J1939 network specific attacks."
                 ->	eavesdrop,
                     _advancedJ1939Attacks,
                     j1939dataflows.maliciousRespond // Respond is generally always supported but requests might not.
 
         & _advancedJ1939Attacks
-                info: "The attacks on this step are advanced in way that if the J1939 protocol is not fully supported, then those might not be sucessful."
-                rationale: "Pal-Stefan Murvay and Bogdan Groza, Security shortcomings and countermeasures for the SAE J1939 commercial vehicle bus protocol (2017)"
+                user info: "The attacks on this step are advanced in way that if the J1939 protocol is not fully supported, then those might not be sucessful."
+                developer info: "Pal-Stefan Murvay and Bogdan Groza, Security shortcomings and countermeasures for the SAE J1939 commercial vehicle bus protocol (2017)"
                 ->	denialOfService,
                     j1939MessageInjection
 
         # noFullJ1939Support
-                info: "If only limited parts of the J1939 protocol are used then the J1939 specific attacks might not work. For example requests might not be supported."
-                rationale: "Pal-Stefan Murvay and Bogdan Groza, Security shortcomings and countermeasures for the SAE J1939 commercial vehicle bus protocol (2017)"
+                user info: "If only limited parts of the J1939 protocol are used then the J1939 specific attacks might not work. For example requests might not be supported."
+                developer info: "Pal-Stefan Murvay and Bogdan Groza, Security shortcomings and countermeasures for the SAE J1939 commercial vehicle bus protocol (2017)"
                 -> _advancedJ1939Attacks
     }
 
     asset FlexRayNetwork extends VehicleNetwork
-        info: "Represents the FlexRay network and the attacks that are possible on it."
+        user info: "Represents the FlexRay network and the attacks that are possible on it."
     {
         | _networkSpecificAttack
-                info: "This attack step should work as an intermediate step to reach network specific attacks."
+                user info: "This attack step should work as an intermediate step to reach network specific attacks."
                 ->	commonTimeBaseAttack,
                     exploitBusGuardian,
                     sleepFrameAttack
 
         | commonTimeBaseAttack [Gamma(2.0,5.0)]
-                info: "Send more than needed (> n/3 where n=# of nodes) SYNC messages within one communication cycle to make the whole network inoperable."
-                rationale: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009)"
+                user info: "Send more than needed (> n/3 where n=# of nodes) SYNC messages within one communication cycle to make the whole network inoperable."
+                developer info: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009)"
                 ->	denialOfService
 
         | exploitBusGuardian [Exponential(15.0)]
-                info: "Utilize Bus Guardian for sending well-directed faked error messages to deactivate controllers. BusGuardian is hardened so much effort is needed."
-                rationale: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009) & Philipp Mundhenk, Sebastian Steinhorst and Suhaib A. Fahmy, Security Analysis of Automotive Architectures using Probabilistic Model Checking (2015)"
+                user info: "Utilize Bus Guardian for sending well-directed faked error messages to deactivate controllers. BusGuardian is hardened so much effort is needed."
+                developer info: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009) & Philipp Mundhenk, Sebastian Steinhorst and Suhaib A. Fahmy, Security Analysis of Automotive Architectures using Probabilistic Model Checking (2015)"
                 ->	networkECUs.offline
 
         & sleepFrameAttack [Exponential(10.0)]
-                info: "Send well-directed forged sleep frames to deactivate power-saving capable FlexRay controller."
-                rationale: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009)"
+                user info: "Send well-directed forged sleep frames to deactivate power-saving capable FlexRay controller."
+                developer info: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009)"
                 ->	networkECUs.offline
 
         # powerSavingIncapableNodes // Might need to be moved on ECU ??? But I leave it here for now...
-                info: "If FlexRay power-saving is not enabled then perform sleep frame attack."
-                rationale: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009)"
+                user info: "If FlexRay power-saving is not enabled then perform sleep frame attack."
+                developer info: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009)"
                 ->	sleepFrameAttack
     }
 
     asset LINNetwork extends VehicleNetwork
-        info: "Represents the LIN bus network and the attacks that are possible on it"
+        user info: "Represents the LIN bus network and the attacks that are possible on it"
     {
         | _networkSpecificAttack
-                info: "This attack step should work as an intermediate step to reach network specific attacks."
+                user info: "This attack step should work as an intermediate step to reach network specific attacks."
                 ->	injectHeaderOrTimedResponse,
                     injectBogusSyncBytes
 
         | injectBogusSyncBytes [Exponential(10.0)]
-                info: "Sending frames with bogus synchronization bytes within the SYNCH field makes the local LIN network inoperative or causes at least serious malfunctions"
-                rationale: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009)"
+                user info: "Sending frames with bogus synchronization bytes within the SYNCH field makes the local LIN network inoperative or causes at least serious malfunctions"
+                developer info: "Marko Wolf, Security Engineering for Vehicular IT Systems, Vieweg+Teubner (2009)"
                 -> denialOfService
 
         | gainLINAccessFromCAN
                 // This attack is reached from ECU
-                info: "There are techniques that make it easy to gain access to the LIN bus through a CAN-bus node."
-                rationale: "Junko Takahashi et al., Automotive Attacks and Countermeasures on LIN-Bus (2017)"
+                user info: "There are techniques that make it easy to gain access to the LIN bus through a CAN-bus node."
+                developer info: "Junko Takahashi et al., Automotive Attacks and Countermeasures on LIN-Bus (2017)"
                 ->	accessNetworkLayer
 
         & injectHeaderOrTimedResponse [Exponential(10.0)]
-                info: "This is a specific attack that can happen on LIN bus exploiting the error handling mechanism, but it is not so easy."
-                rationale: "Junko Takahashi et al., Automotive Attacks and Countermeasures on LIN-Bus (2017)"
+                user info: "This is a specific attack that can happen on LIN bus exploiting the error handling mechanism, but it is not so easy."
+                developer info: "Junko Takahashi et al., Automotive Attacks and Countermeasures on LIN-Bus (2017)"
                 ->	dataflows.maliciousTransmit // This is different from the messageInjection attack because, if successful, allows direct malicious respond and request.
 
         # headerOrTimedResponseProtection
-                info: "Based on the defense mechanism proposed by the related paper."
-                rationale: "Junko Takahashi et al., Automotive Attacks and Countermeasures on LIN-Bus (2017)"
+                user info: "Based on the defense mechanism proposed by the related paper."
+                developer info: "Junko Takahashi et al., Automotive Attacks and Countermeasures on LIN-Bus (2017)"
                 ->	injectHeaderOrTimedResponse
 
         // LIN is also unprotected against forged messages. So messageInjection exists also here.
@@ -618,80 +618,80 @@ category Networking {
 category Communication {
 
     asset Information
-        info: "Information can be stored as data and transmitted in data flows. Data and data flows are syntactic forms of the semantics represented by the Information asset. Thus, multiple data and data flow assets can contain the same information."
+        user info: "Information can be stored as data and transmitted in data flows. Data and data flows are syntactic forms of the semantics represented by the Information asset. Thus, multiple data and data flow assets can contain the same information."
     {
         | read
-            info: "When information is read by the attacker, any associated confidentiality costs are incurred. It is sufficient that the attacker reads a single data or data flow to breach confidentiality."
+            user info: "When information is read by the attacker, any associated confidentiality costs are incurred. It is sufficient that the attacker reads a single data or data flow to breach confidentiality."
 
         & write
-            info: "When information is written by the attacker, any associated integrity costs are incurred. The attacker must, however, compromise all data and data flows in order to breach integrity. Thus, if the records of an ATM are modified, this might incur no cost as long as the master data is untouched."
+            user info: "When information is written by the attacker, any associated integrity costs are incurred. The attacker must, however, compromise all data and data flows in order to breach integrity. Thus, if the records of an ATM are modified, this might incur no cost as long as the master data is untouched."
 
         & delete
-            info: "When information is deleted by the attacker, any associated availability costs are incurred. The attacker must, however, delete all data and data flows in order to breach integrity. Thus, if malware wipes a hard drive, this might incur no cost as long as a backup is easily accessible."
+            user info: "When information is deleted by the attacker, any associated availability costs are incurred. The attacker must, however, delete all data and data flows in order to breach integrity. Thus, if malware wipes a hard drive, this might incur no cost as long as a backup is easily accessible."
     }
 
     asset Data
-        info: "Data is a concrete, syntactic representation of Information at rest."
+        user info: "Data is a concrete, syntactic representation of Information at rest."
     {
         | requestAccess
-                info: "When stored on a machine, access control needs to be granted."
+                user info: "When stored on a machine, access control needs to be granted."
                 ->	authenticatedRead,
                     authenticatedWrite,
                     authenticatedDelete
 
         | anyAccountRead
-                info: "A single account with read privileges (in conjuction with data access) is enough to read the data."
+                user info: "A single account with read privileges (in conjuction with data access) is enough to read the data."
                 ->	authenticatedRead
 
         | anyAccountWrite
-                info: "A single account with write privileges (in conjuction with data access) is enough to write the data."
+                user info: "A single account with write privileges (in conjuction with data access) is enough to write the data."
                 ->	authenticatedWrite
 
         | anyAccountDelete
-                info: "A single account with delete privileges (in conjuction with data access) is enough to delete the data."
+                user info: "A single account with delete privileges (in conjuction with data access) is enough to delete the data."
                 ->	authenticatedDelete
 
         & authenticatedRead
-                info: "An account with read privileges in conjuction with data access allows reading of the data."
+                user info: "An account with read privileges in conjuction with data access allows reading of the data."
                 -> 	read
 
         & authenticatedWrite
-                info: "An account with write privileges in conjuction with data access allows writing of the data."
+                user info: "An account with write privileges in conjuction with data access allows writing of the data."
                 -> 	write
 
         & authenticatedDelete
-                info: "An account with delete privileges in conjuction with data access allows deletion of the data."
+                user info: "An account with delete privileges in conjuction with data access allows deletion of the data."
                 -> 	delete
 
         | read
-                info: "An attacker that reads the data, learns the encoded information."
+                user info: "An attacker that reads the data, learns the encoded information."
                 ->	information.read,
                     containedData.read
 
         | write
-                info: "Tampering with data leads to altering of the contained information only if there is no untouched copy elsewhere. If data is transmitted through data flows, those data flows will also be affected by the tampering."
+                user info: "Tampering with data leads to altering of the contained information only if there is no untouched copy elsewhere. If data is transmitted through data flows, those data flows will also be affected by the tampering."
                 -> 	delete, // NOTE: Is this needed ???
                     information.write,
                     containedData.write
 
         | delete
-                info: "Deletion of data leads to information loss only if there is no untouched copy elsewhere. If data is transmitted through data flows, those data flows will also be affected by the tampering."
+                user info: "Deletion of data leads to information loss only if there is no untouched copy elsewhere. If data is transmitted through data flows, those data flows will also be affected by the tampering."
                 ->	information.delete,
                     containedData.delete
 
         | denyAccess
-                info: "Denial-of-service attacks can make data unavailable."
+                user info: "Denial-of-service attacks can make data unavailable."
     }
 
     abstract asset Dataflow
-        info: "Dataflow is a channel that contains Data in transit."
+        user info: "Dataflow is a channel that contains Data in transit."
     {
         | eavesdrop
-                info: "An attacker that eavesdrops on the data flow, can access the contained data. That data may, in turn, be encrypted, thus preventing a breach of confidentiality."
+                user info: "An attacker that eavesdrops on the data flow, can access the contained data. That data may, in turn, be encrypted, thus preventing a breach of confidentiality."
                 ->	data.read
 
         | denialOfService
-                info: "A denial-of-service-attack on the dataflow makes the contained data inaccessible. The information may, however also be available elsewhere."
+                user info: "A denial-of-service-attack on the dataflow makes the contained data inaccessible. The information may, however also be available elsewhere."
                 ->	data.delete
 
         | manInTheMiddle
@@ -710,10 +710,10 @@ category Communication {
     }
 
     asset ConnectionOrientedDataflow extends Dataflow
-        info: "A connection oriented dataflow is a unicast/multicast transmission that contains Data in transit."
+        user info: "A connection oriented dataflow is a unicast/multicast transmission that contains Data in transit."
     {
         | manInTheMiddle
-                info: "An attacker that man-in-the-middles the data flow, can control the contained data. That data may, in turn, be encrypted and authenticated, thus preventing a breach of confidentiality and integrity."
+                user info: "An attacker that man-in-the-middles the data flow, can control the contained data. That data may, in turn, be encrypted and authenticated, thus preventing a breach of confidentiality and integrity."
                 ->	eavesdrop,
                     denialOfService,
                     request,
@@ -730,20 +730,20 @@ category Communication {
                     //executingClients.access
 
         | maliciousRespond [Exponential(6.14)]
-                info: "Confliction protection mechanism does not prevent malicious responds, but it typically takes time for the attacker to bypass it."
+                user info: "Confliction protection mechanism does not prevent malicious responds, but it typically takes time for the attacker to bypass it."
                 -> respond
     }
 
     asset ConnectionlessDataflow extends Dataflow
-        info: "A connectionless dataflow is a multicast/broadcast transmission that contains Data in transit."
-        rationale: "In a broadcast network, there is no need to have clients because everyone receives the message. Additionaly, in an event-driven netwrok like CAN, there is no need for request."
+        user info: "A connectionless dataflow is a multicast/broadcast transmission that contains Data in transit."
+        developer info: "In a broadcast network, there is no need to have clients because everyone receives the message. Additionaly, in an event-driven netwrok like CAN, there is no need for request."
     {
         | eavesdrop
-                info: "An attacker that eavesdrops on the data flow, can access the contained data. That data may, in turn, be encrypted, thus preventing a breach of confidentiality."
+                user info: "An attacker that eavesdrops on the data flow, can access the contained data. That data may, in turn, be encrypted, thus preventing a breach of confidentiality."
                 -> 	data.read
 
         | manInTheMiddle
-                info: "An attacker that man-in-the-middles the data flow, can control the contained data. That data may, in turn, be encrypted and authenticated, thus preventing a breach of confidentiality and integrity."
+                user info: "An attacker that man-in-the-middles the data flow, can control the contained data. That data may, in turn, be encrypted and authenticated, thus preventing a breach of confidentiality and integrity."
                 -> 	eavesdrop,
                     denialOfService,
                     data.write,
@@ -753,24 +753,24 @@ category Communication {
                     // This agrees with the current securiCore implementation. MiTM leads to direct request/respond.
 
         | maliciousTransmitNoIDPS
-                info: "Perform a malicious transmission when IDPS is disabled on GatewayECU. However even when IDPS is off effort is needed to bypass message confliction mechanism."
+                user info: "Perform a malicious transmission when IDPS is disabled on GatewayECU. However even when IDPS is off effort is needed to bypass message confliction mechanism."
                 ->	maliciousTransmitBypassConflitionProtection
 
         | maliciousTransmitBypassConflitionProtection [Exponential(3.14)]
-                info: "Confliction protection mechanism does not prevent malicious transmissions, but it typically takes time for the attacker to bypass it."
+                user info: "Confliction protection mechanism does not prevent malicious transmissions, but it typically takes time for the attacker to bypass it."
                 -> transmit
 
         | maliciousTransmitBypassIDPS [Exponential(6.13)]
-                info: "IDPS's does not prevent all malicious transmissions, and it typically takes time for the attacker to bypass it."
-                rationale: "The time to bypass a tuned and updated IDPS is studied in 'T. Sommestad, H. Holm, M. Ekstedt, Estimates of success rates of remote arbitrary code execution attacks, Information Management & Computer Security (2012)' and 'H.Holm, T.Sommestad, U.Franke, M.Ekstedt, Success rate of remote code execution attacks – expert assessments and observations, Journal of Universal Computer Science 18 (6) (2012)'"
+                user info: "IDPS's does not prevent all malicious transmissions, and it typically takes time for the attacker to bypass it."
+                developer info: "The time to bypass a tuned and updated IDPS is studied in 'T. Sommestad, H. Holm, M. Ekstedt, Estimates of success rates of remote arbitrary code execution attacks, Information Management & Computer Security (2012)' and 'H.Holm, T.Sommestad, U.Franke, M.Ekstedt, Success rate of remote code execution attacks – expert assessments and observations, Journal of Universal Computer Science 18 (6) (2012)'"
                 ->	transmit
 
         | maliciousTransmit
-                info: "The act of trying to maliciously transmit. This happens when IDPS is not in place so the attacker can make malicious transmissions unobstructed. Reached only from network specific attacks and network service."
+                user info: "The act of trying to maliciously transmit. This happens when IDPS is not in place so the attacker can make malicious transmissions unobstructed. Reached only from network specific attacks and network service."
                 ->	transmit
 
         | transmit
-                info: "The result of a successful transmit."
+                user info: "The result of a successful transmit."
                 ->	transmitter.connect
     }
 }
@@ -780,18 +780,18 @@ category Security {
     asset Vulnerability 
     {
         | exploit [Exponential(10.0)]
-                info: "An attacker can exploit a known vulnerability."
+                user info: "An attacker can exploit a known vulnerability."
                   -> privileges.compromise // Compromise account after exploiting vulnerability
     }
 
     asset Account 
     {
         | authenticate
-                info: "After authentication on an account, compromise its privileges."
+                user info: "After authentication on an account, compromise its privileges."
                 ->	compromise
 
         | compromise
-                info: "A compromised account leads to authentication on machines, access rights on data and also authentication on other connected accounts."
+                user info: "A compromised account leads to authentication on machines, access rights on data and also authentication on other connected accounts."
                 -> 	accessedMachines.authenticate,
                     readData.anyAccountRead,
                     writtenData.anyAccountWrite,
@@ -799,33 +799,33 @@ category Security {
                     authenticatees.authenticate
 
         |  idAuthenticate
-                info: "After ID based authentication on an account, compromise its privileges."
+                user info: "After ID based authentication on an account, compromise its privileges."
                 ->  accessedMachines.idAccess
     }
 
     asset Credentials extends Data 
     {
         | read
-                info: "The action of reading the credentials stored on data."
+                user info: "The action of reading the credentials stored on data."
                 -> 	accounts.authenticate,
                     readFirmwareAccessKey
 
         | readFirmwareAccessKey
-                info: "The action of reading a stored firmware validation/access key."
+                user info: "The action of reading a stored firmware validation/access key."
                 ->  machines.passFirmwareValidation,
                     machines.passUdsFirmwareModification
     }
 
     asset MessageID extends Credentials
-        info: "Represents the ID that resides on the header of a transmitted packet/message/dataflow."
+        user info: "Represents the ID that resides on the header of a transmitted packet/message/dataflow."
     {
         | read
-                info: "The action of reading the ID stored on data/dataflow."
+                user info: "The action of reading the ID stored on data/dataflow."
                 -> 	accounts.idAuthenticate
     }
 
     asset IDPS extends Service
-        info: "An IDPS detects and prevents some malicious requests and responses in dataflows. Here it is modeled as a centralized inline IDPS."
+        user info: "An IDPS detects and prevents some malicious requests and responses in dataflows. Here it is modeled as a centralized inline IDPS."
     {
         // Intentionally left blank
     }
@@ -843,11 +843,11 @@ category User {
 associations {
     Machine			[executor]						0..1<-- Execution						--> *	[executees]						Software
     Account 		[account]			  			*	<-- AccessPrivileges				--> *	[accessedMachines]				Machine
-        info: "These accounts grant access the the machine."
+        user info: "These accounts grant access the the machine."
     Account 		[connectPrivileges] 			*	<-- ConnectionPrivileges			--> *	[connectMachines]				Machine
-        info: "These privileges are granted to anyone who connects to a machine."
+        user info: "These privileges are granted to anyone who connects to a machine."
     Account 		[assignedAccounts]				*	<-- Assignment						--> *	[assignedSoftwares] 			Software
-        info: "Software needs to be granted certain privileges when executing on a platform. When the software is compromised, the attacker gains its privileges on the platform."
+        user info: "Software needs to be granted certain privileges when executing on a platform. When the software is compromised, the attacker gains its privileges on the platform."
     Account 		[authenticators]				*	<-- Authentication					--> *	[authenticatees]		 		Account
     Account 		[accounts]						*  	<-- Credentials						--> *	[credentials] 					Credentials
     Account 		[readingAccounts]				*  	<-- Read							--> *	[readData] 						Data
@@ -855,28 +855,28 @@ associations {
     Account 		[deletingAccounts]				*  	<-- Delete							--> *	[deletedData] 					Data
     Data			[containingData] 				*	<-- Containment 					--> *	[containedData] 				Data
     Data			[data] 							*	<-- Representation 					--> 0..1[information] 					Information
-        info: "The data constitutes a syntactic representation at rest of the information."
+        user info: "The data constitutes a syntactic representation at rest of the information."
     Data			[data] 							*	<-- Storage 						--> *	[machines]	 					Machine
     Network 		[networks]						* 	<-- Communication 					--> *	[dataflows] 					Dataflow
-        info: "In general, networks use dataflows for communication."
+        user info: "In general, networks use dataflows for communication."
     Network [networks] 								* 	<-- NetworkConnection 				--> * 	[networkMachines]				Machine
-        info: "Machines can be connected to networks. If services are not explicitly connected to other networks, it is assumed that they are communicating over the physically connected one."
+        user info: "Machines can be connected to networks. If services are not explicitly connected to other networks, it is assumed that they are communicating over the physically connected one."
     J1939Network	[j1939networks]					* 	<-- J1939Communication 				--> *	[j1939dataflows] 				ConnectionOrientedDataflow
-        info: "A J1939 network uses connection oriented dataflows for communication although it is a CAN-based network."
+        user info: "A J1939 network uses connection oriented dataflows for communication although it is a CAN-based network."
     Dataflow		[dataflow]						0..1<-- DataTransfer					--> 0..1[data] 							Data
-        info: "The dataflow transmits data."
-        rationale: "A dataflow cannot feature multiple data, as these may have different properties, e.g. one authenticated and one not."
+        user info: "The dataflow transmits data."
+        developer info: "A dataflow cannot feature multiple data, as these may have different properties, e.g. one authenticated and one not."
     Dataflow		[dataflows]						* 	<-- Request							--> *	[clients]						NetworkClient
     Dataflow		[dataflows]						* 	<-- Response						--> *	[services]						NetworkService
-        info: "A network service or a network client makes use of dataflows that can be either connection oriented or connectionless."
+        user info: "A network service or a network client makes use of dataflows that can be either connection oriented or connectionless."
     //Network 		[networks]						* 	<-- Listening						--> *	[networkServices]	 			NetworkService
-    //    info: "A network service, which uses connection oriented dataflows, can be directly connected to a network."
+    //    user info: "A network service, which uses connection oriented dataflows, can be directly connected to a network."
     ConnectionlessDataflow [dataflows]				* 	<-- Transmission					--> 0..1[transmitter]					TransmitterService
-        info: "A transmitter service on a vehicle network uses connectionless dataflows for transmitting data."
+        user info: "A transmitter service on a vehicle network uses connectionless dataflows for transmitting data."
     ConnectionlessDataflow [dataflows]				* 	<-- Transmission					--> *	[receiver]						VehicleNetworkReceiver
-        info: "A receiver uses connectionless dataflows for receiving data on a vehicle network."
+        user info: "A receiver uses connectionless dataflows for receiving data on a vehicle network."
     IDPS			[idps]							/***/0..1<-- IDPSProtection					--> 1	[idpsGatewayECU]				GatewayECU
-        info: "An IDPS can be connected to a GatewayECU. Here it is modeled as a centralized inline IDPS."
+        user info: "An IDPS can be connected to a GatewayECU. Here it is modeled as a centralized inline IDPS."
     User			[users]							*  	<-- UserAccount 					--> *	[accounts]						Account
     Machine			[connectionVulnerableMachine]	*	<-- ConnectionVulnerability			--> 0..1[connectionVulnerabilities]		Vulnerability
     Machine			[accessVulnerableMachine]		*	<-- AccessVulnerability				--> 0..1[accessVulnerabilities]			Vulnerability
@@ -884,11 +884,11 @@ associations {
     VehicleNetwork 	[vehiclenetworks] 				* 	<-- Connection 						--> * 	[networkECUs] 					ECU
     VehicleNetwork 	[trafficVNetworks] 				* 	<-- Connection 						--> * 	[trafficGatewayECU]				GatewayECU
     ECU				[hardware]						1	<-- FirmwareExecution				--> 0..1[firmware]						Firmware
-        info: "Every ECU can have (up to one) firmware running on it."
+        user info: "Every ECU can have (up to one) firmware running on it."
     ECU				[firmwareTarget]				1	<-- FirmwareUpdate					--> 0..1[firmwareUpdater]				FirmwareUpdaterService
-        info: "Every ECU can have a firmware updater UDS service responsible for handling the firmware updates."
+        user info: "Every ECU can have a firmware updater UDS service responsible for handling the firmware updates."
     ECU 			[hardwarePlatform]				0..1<-- SensorsOrActuators				--> *	[sensorsOrActuators]			SensorOrActuator
-        info: "An ECU can be connected with physical machines such as actuators and/or sensors."
+        user info: "An ECU can be connected with physical machines such as actuators and/or sensors."
     VehicleNetwork 	[fwUpdaterNetworks] 			0..1<-- FwUpdaterServices               --> * 	[networkFwUpdater] 				FirmwareUpdaterService
-        info: "A FirmwareUpdaterService can be connected to a vehicle network for accepting incoming connections."
+        user info: "A FirmwareUpdaterService can be connected to a vehicle network for accepting incoming connections."
 }

--- a/malcompiler-test/src/test/resources/vehiclelang/vehicleLangEthernet.mal
+++ b/malcompiler-test/src/test/resources/vehiclelang/vehicleLangEthernet.mal
@@ -1,31 +1,31 @@
 category System {
 
     asset EthernetGatewayECU extends GatewayECU
-        info: "Specifies a Gateway ECU that has additionaly Ethernet network capabilities."
+        user info: "Specifies a Gateway ECU that has additionaly Ethernet network capabilities."
         {
         | access
-                rationale: "Overriding from GatewayECU"
+                developer info: "Overriding from GatewayECU"
                 +>	trafficVNetworks.manInTheMiddle, // This will act as Firewall and IDPS are disabled on vehicle networks
                     trafficNetworks.manInTheMiddle, // This will act as above but on the ethernet network
                     forwarding
 
         | forwarding
-                rationale: "Forwarding is the lightest interaction with the gateway, where the gateway simply retransmits received messages. Vulnerabilities may, however, lead to compromise of the gateway as well as of the associated firewall. Therefore, Forwarding leads to Connect."
+                developer info: "Forwarding is the lightest interaction with the gateway, where the gateway simply retransmits received messages. Vulnerabilities may, however, lead to compromise of the gateway as well as of the associated firewall. Therefore, Forwarding leads to Connect."
                 -> 	connect,
                     bypassFirewall  // If firewall is not enabled then bypass it.
 
         & bypassFirewall
-                info: "If firewall is disabled, then attacker can bypass it."
+                user info: "If firewall is disabled, then attacker can bypass it."
                 ->	gatewayBypassIDPS, // Added here to stop those attacks when firewall is enabled.
                     gatewayNoIDPS,
                     trafficNetworks.accessNetworkLayer
 
         # firewallProtection // Firewall is just a defense on gateway ECU.
-                info: "Firewall protection comes from the existence of a correctly configured firewall."
+                user info: "Firewall protection comes from the existence of a correctly configured firewall."
                 -> bypassFirewall
 
         | denialOfService
-                info: "Perform denial of service attack on all the connected networks."
+                user info: "Perform denial of service attack on all the connected networks."
                 -> 	trafficVNetworks.denialOfService,
                     trafficNetworks.denialOfService
         }
@@ -44,11 +44,11 @@ category Networking {
                 ->	noFirewallProtection
 
         | noFirewallProtection
-                info: "Firewall protection comes from (i) the existence of a (ii) correctly configured firewall."
+                user info: "Firewall protection comes from (i) the existence of a (ii) correctly configured firewall."
                 -> bypassFirewall
 
         | forwarding
-                rationale: "Forwarding is the lightest interaction with the router, where the router simply retransmits received messages. Vulnerabilities may, however, lead to compromise of the router as well as of the associated firewall. Therefore, Forwarding leads to Connect."
+                developer info: "Forwarding is the lightest interaction with the router, where the router simply retransmits received messages. Vulnerabilities may, however, lead to compromise of the router as well as of the associated firewall. Therefore, Forwarding leads to Connect."
                 -> 	connect,
                     bypassFirewall
 
@@ -60,10 +60,10 @@ category Networking {
         }
 
     asset EthernetNetwork extends Network
-        info: "This represents the homonym network when using IPv4."
+        user info: "This represents the homonym network when using IPv4."
         { 	
         | physicalAccess
-                info: "Physical access currently includes close-enough-to-touch."
+                user info: "Physical access currently includes close-enough-to-touch."
                 -> 	bypassPortSecurity
         
          & bypassPortSecurity
@@ -73,13 +73,13 @@ category Networking {
                 -> 	accessDataLinkLayer
 
         | accessDataLinkLayer
-                info: "Hosts with a MAC address on the network have Layer 2 access."
-                rationale: "Access to data link layer (OSI layer 2) may enable eavesdropping, depending on the kind of network, as well as ARP cache poisoning either on the router side or any of the hosts on the network. (Router side ARP cache poisoning is modelled as a property on the network.)"
+                user info: "Hosts with a MAC address on the network have Layer 2 access."
+                developer info: "Access to data link layer (OSI layer 2) may enable eavesdropping, depending on the kind of network, as well as ARP cache poisoning either on the router side or any of the hosts on the network. (Router side ARP cache poisoning is modelled as a property on the network.)"
                 -> 	accessNetworkLayer, 
                     aRPCachePoisoning
   
         | accessNetworkLayer
-                info: "Network layer (OSI layer 3) access implies the possibility to submit IP packets over the network. It does not imply the possibility to listen to others' trafic on the network. You are outside the router but with a possibility to communicate in to the network."
+                user info: "Network layer (OSI layer 3) access implies the possibility to submit IP packets over the network. It does not imply the possibility to listen to others' trafic on the network. You are outside the router but with a possibility to communicate in to the network."
                 -> 	networkMachines[NetworkService].connect,
                     trafficRouters.forwarding,
                     trafficEthGatewayECU.forwarding,
@@ -87,19 +87,19 @@ category Networking {
                     networkMachines.connect
   
         & aRPCachePoisoning
-            info: "ARP spoofing works on all common IPv4 networks, both wirebound and wireless. For WPA2Enterprise, it can be exploited due to Hole196 (cf. https://www.cwnp.com/forums/posts?postNum=300580)."
+            user info: "ARP spoofing works on all common IPv4 networks, both wirebound and wireless. For WPA2Enterprise, it can be exploited due to Hole196 (cf. https://www.cwnp.com/forums/posts?postNum=300580)."
                 -> 	manInTheMiddle
  
         # portSecurity
-                info: "You can use port security to restrict a port's ingress traffic by limiting the MAC addresses that are allowed to send traffic into the port."
-                rationale: "http://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst6500/ios/12-2SX/configuration/guide/book/port_sec.html"
+                user info: "You can use port security to restrict a port's ingress traffic by limiting the MAC addresses that are allowed to send traffic into the port."
+                developer info: "http://www.cisco.com/c/en/us/td/docs/switches/lan/catalyst6500/ios/12-2SX/configuration/guide/book/port_sec.html"
                 -> 	bypassPortSecurity
 
         # staticARPTables 
                 -> 	aRPCachePoisoning
 
         | manInTheMiddle
-                    info: "Attackers can sometimes intercept and tamper with communications on the IP layer. Higher-layer encryption and authentication, such as HTTPS, may still prevent the compromise of information in dataflows."
+                    user info: "Attackers can sometimes intercept and tamper with communications on the IP layer. Higher-layer encryption and authentication, such as HTTPS, may still prevent the compromise of information in dataflows."
                 -> 	accessDataLinkLayer,
                     eavesdrop,
                     dataflows.manInTheMiddle,

--- a/malcompiler-test/src/test/resources/vehiclelang/vehicleLangPublicInterfaces.mal
+++ b/malcompiler-test/src/test/resources/vehiclelang/vehicleLangPublicInterfaces.mal
@@ -1,24 +1,24 @@
 category System {
 
     asset InfotainmentSystem extends Machine
-        info: "Represents the information & entertainment system found on all modern cars. It is a machine which can be connected to one or more networks."
-        rationale: "It has the same functionality as a machine plus one additional attack step that is reached only when the NetworkAccessService is compromised."
+        user info: "Represents the information & entertainment system found on all modern cars. It is a machine which can be connected to one or more networks."
+        developer info: "It has the same functionality as a machine plus one additional attack step that is reached only when the NetworkAccessService is compromised."
         {
         | access
-                rationale: "Adding one new connected attack step"
+                developer info: "Adding one new connected attack step"
                 +>  engineerNetworkAccess
 
         | gainNetworkAccess
-                info: "If this attack step is reached then full network layer access is gained by the attacker."
+                user info: "If this attack step is reached then full network layer access is gained by the attacker."
                 ->	connectedNetworks.accessNetworkLayer
 
         | engineerNetworkAccess [Exponential(10.0)]
-                info: "This attack step is another way to reach full network access if there is no network access service on the infotainment system, but it requires effort!"
+                user info: "This attack step is another way to reach full network access if there is no network access service on the infotainment system, but it requires effort!"
                 ->	connectedNetworks.accessNetworkLayer
         }
 
     asset NetworkAccessService extends NetworkService
-        info: "This service might run on an infotainment system and if compromised allows the attacker to access the networks connected to it."
+        user info: "This service might run on an infotainment system and if compromised allows the attacker to access the networks connected to it."
         {
         | access
                 +>	executor.gainNetworkAccess
@@ -28,10 +28,10 @@ category System {
 category Communication {
 
     asset OBD2Connector
-        info: "Represents the OBD-II connector available in all modern cars and most vehicles in general."
+        user info: "Represents the OBD-II connector available in all modern cars and most vehicles in general."
         {
         | physicalAccess
-                info: "Physical access to the connector leads to access on the network layer."
+                user info: "Physical access to the connector leads to access on the network layer."
                 ->	interfacingNetworks.accessNetworkLayer
 
         | connect
@@ -39,39 +39,39 @@ category Communication {
                 _connectNoProtection
 
         | bypassConnectorProtection [Exponential(20.0)]
-                info: "Remove or bypass objects blocking the OBD connector, for example ripping of protective plate or ganining access to driver cabin. Requires effort"
+                user info: "Remove or bypass objects blocking the OBD connector, for example ripping of protective plate or ganining access to driver cabin. Requires effort"
                 ->	physicalAccess
 
         & _connectNoProtection
                 -> 	physicalAccess
 
         # connectorAccessProtection
-                info: "Any type of physical entity blocking attackers from physically connecting to the OBD-II port. For example a protective plate covering the port or port being placed where it's difficult to access."
+                user info: "Any type of physical entity blocking attackers from physically connecting to the OBD-II port. For example a protective plate covering the port or port being placed where it's difficult to access."
                 ->	_connectNoProtection
         }
 
     asset ChargingPlugConnector
-        info: "The charging plug on many electric vehicles provides direct CAN bus access, while on others is only connected to the same network as the Battery Management System (BMS) ECU."
-        rationale: "Florian Sagstetter, Security Challenges in Automotive Hardware/Software Architecture Design (2013)"
+        user info: "The charging plug on many electric vehicles provides direct CAN bus access, while on others is only connected to the same network as the Battery Management System (BMS) ECU."
+        developer info: "Florian Sagstetter, Security Challenges in Automotive Hardware/Software Architecture Design (2013)"
         {
         | physicalAccess
-                info: "No matter the case, physical access to the connector leads to access on the network layer of the connected network."
+                user info: "No matter the case, physical access to the connector leads to access on the network layer of the connected network."
                 ->	connectedNetwork.accessNetworkLayer
         }
 
     asset AftermarketDongle
-        info: "An aftermarket dongle is a device that connects to the OBD-II port and provides some additional functionality to the vehicle's owner (e.g. error log reading, vehicle configuration, etc."
+        user info: "An aftermarket dongle is a device that connects to the OBD-II port and provides some additional functionality to the vehicle's owner (e.g. error log reading, vehicle configuration, etc."
         {
         | connectDongle
-                info: "When a dongle is connected, the connect attack step is reached on OBD-II connector."
+                user info: "When a dongle is connected, the connect attack step is reached on OBD-II connector."
                 ->	_connectToNetwork
 
         & _connectToNetwork
                 ->	connector.connect
 
         # dongleIsHardened
-                info: "If the firmware on the connected dongle cannot be modified by the attacker, then access on the network layer cannto be achieved."
-                rationale: "This defense might look more logical in the future where an external attacker will be able to use the dongle as an entry point in the vehicle."
+                user info: "If the firmware on the connected dongle cannot be modified by the attacker, then access on the network layer cannto be achieved."
+                developer info: "This defense might look more logical in the future where an external attacker will be able to use the dongle as an entry point in the vehicle."
                 ->	_connectToNetwork
         }
 }

--- a/update_mal/new-spec.mal
+++ b/update_mal/new-spec.mal
@@ -14,7 +14,7 @@ category C1 {
 }
 
 category C2
-  info: "info"
+  user info: "info"
 {
   asset A1 {
     & At1
@@ -25,7 +25,7 @@ category C2
   }
 
   asset A2
-    info: "info"
+    user info: "info"
   {
     & At1 [Bernoulli(0.7)]
     & At2 [Binomial(0.5, 0.6)]
@@ -41,26 +41,26 @@ category C2
   }
 
   asset A3
-    rationale: "rationale"
+    developer info: "rationale"
   {
     & At1
     & At2
-      info: "info"
+      user info: "info"
     & At3
-      rationale: "rationale"
+      developer info: "rationale"
     & At4
-      assumptions: "assumptions"
+      modeler info: "assumptions"
     & At5
-      info: "info"
-      assumptions: "assumptions"
+      user info: "info"
+      modeler info: "assumptions"
     & At6
-      info: "info"
-      rationale: "rationale"
-      assumptions: "assumptions"
+      user info: "info"
+      developer info: "rationale"
+      modeler info: "assumptions"
   }
 
   asset A4
-    assumptions: "assumptions"
+    modeler info: "assumptions"
   {
     & A1
       <- A
@@ -69,8 +69,8 @@ category C2
   }
 
   asset A5
-    info: "info"
-    assumptions: "assumptions"
+    user info: "info"
+    modeler info: "assumptions"
   {
     & A1
       -> let v1 = a,
@@ -88,39 +88,39 @@ category C2
   }
 
   asset A6
-    info: "info"
-    rationale: "rationale"
-    assumptions: "assumptions"
+    user info: "info"
+    developer info: "rationale"
+    modeler info: "assumptions"
   {
   }
 }
 
 category C3
-  rationale: "rationale"
+  developer info: "rationale"
 {
   asset A1 extends A1 {
   }
 }
 
 category C4
-  assumptions: "assumptions"
+  modeler info: "assumptions"
 {
   abstract asset A1 {
   }
 }
 
 category C5
-  info: "info"
-  assumptions: "assumptions"
+  user info: "info"
+  modeler info: "assumptions"
 {
   asset distribution {
   }
 }
 
 category C6
-  info: "info"
-  rationale: "rationale"
-  assumptions: "assumptions"
+  user info: "info"
+  developer info: "rationale"
+  modeler info: "assumptions"
 {
 }
 
@@ -131,18 +131,18 @@ associations {
 
 assocations {
   A  [a]  1   <-- A  --> 1   [a]  A
-    info: "info"
+    user info: "info"
   A  [a]  1   <-- A  --> 1   [a]  A
-    rationale: "rationale"
+    developer info: "rationale"
   A  [a]  1   <-- A  --> 1   [a]  A
-    assumptions: "assumptions"
+    modeler info: "assumptions"
   A  [a]  1   <-- A  --> 1   [a]  A
-    info: "info"
-    assumptions: "assumptions"
+    user info: "info"
+    modeler info: "assumptions"
   A  [a]  1   <-- A  --> 1   [a]  A
-    info: "info"
-    rationale: "rationale"
-    assumptions: "assumptions"
+    user info: "info"
+    developer info: "rationale"
+    modeler info: "assumptions"
 }
 
 // Comment

--- a/update_mal/update_mal.py
+++ b/update_mal/update_mal.py
@@ -224,8 +224,17 @@ class MalUpdater():
                     self.write('E')
                     if self.in_asset:
                         self.in_attackstep = True
-                elif identifier == 'info' or identifier == 'rationale' or identifier == 'assumptions':
-                    self.write(identifier)
+                elif identifier == 'info':
+                    # Keyword 'info' has changed to 'user info'
+                    self.write('user info')
+                    self.in_attackstep = False
+                elif identifier == 'rationale':
+                    # Keyword 'rationale' has changed to 'developer info'
+                    self.write('developer info')
+                    self.in_attackstep = False
+                elif identifier == 'assumptions':
+                    # Keyword 'assumptions' has changed to 'modeler info'
+                    self.write('modeler info')
                     self.in_attackstep = False
                 elif identifier == 'include':
                     self.write('include')


### PR DESCRIPTION
```
& compromise
  info: "True"
  rationale: "Display"
  assumptions: "Edge"
```
Is now written as
```
& compromise
  user info: "True"
  developer info: "Display"
  modeler info: "Edge"
```