### PR TITLE
More permissive syntax

### DIFF
--- a/grammar
+++ b/grammar
@@ -23,11 +23,9 @@
 <reaches>       ::= (INHERIT | OVERRIDE) <expr> (COMMA <expr>)*
 
 <variable>      ::= LET ID ASSIGN <expr>
-<expr>          ::= <step> ((UNION | INTERSECT | MINUS) <step>)*
-<step>          ::= <transitive> (DOT <transitive>)*
-<transitive>    ::= <subtype> STAR?
-<subtype>       ::= <prim> <type>?
-<prim>          ::= ID (LPAREN RPAREN)? | LPAREN <expr> RPAREN
+<expr>          ::= <steps> ((UNION | INTERSECT | MINUS) <steps>)*
+<steps>         ::= <step> (DOT <step>)*
+<step>          ::= (LPAREN <expr> RPAREN | ID (LPAREN RPAREN)?) (STAR | <type>)*
 
 <associations>  ::= ASSOCIATIONS LCURLY <associations1>? RCURLY
 <associations1> ::= ID <association> (ID (<meta2> | <association>))*

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/reference/TestReferenceGenerator.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/reference/TestReferenceGenerator.java
@@ -288,4 +288,9 @@ public class TestReferenceGenerator extends JavaGeneratorTest {
   public void testNested() {
     assertLangGenerated("generator/nested.mal");
   }
+
+  @Test
+  public void testSteps() {
+    assertLangGenerated("generator/steps.mal");
+  }
 }

--- a/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/securicad/TestSecuricadGenerator.java
+++ b/malcompiler-test/src/test/java/org/mal_lang/compiler/test/lib/securicad/TestSecuricadGenerator.java
@@ -402,4 +402,9 @@ public class TestSecuricadGenerator extends JavaGeneratorTest {
   public void testNested() {
     assertLangGenerated("generator/nested.mal");
   }
+
+  @Test
+  public void testSteps() {
+    assertLangGenerated("generator/steps.mal");
+  }
 }

--- a/malcompiler-test/src/test/resources/generator/steps.mal
+++ b/malcompiler-test/src/test/resources/generator/steps.mal
@@ -1,0 +1,35 @@
+#id: "steps"
+#version: "0.0.0"
+
+category System {
+  asset Alpha {
+    | compromise ->
+      bravos.subbravos*.access,
+      bravos.subbravos*[SubBravo].access,
+      bravos[SubBravo].subbravos*.access,
+      bravos[SubBravo].subbravos[SubBravo]*.access,
+      bravos.subbravos**.access,
+      bravos.subbravos**[SubBravo].access,
+      bravos[SubBravo].subbravos**[SubBravo]*.access,
+      bravos[SubSubBravo].access,
+      bravos[SubBravo][SubSubBravo].access,
+      bravos.SUB()*.access,
+      bravos.SUB()**.access,
+      bravos[SubBravo].SUB()*.access,
+      bravos[SubBravo].SUB()[SubBravo]*.access,
+      bravos.(SUB()*)*.access
+  }
+  asset Bravo {
+    let SUB = subbravos
+    | access
+  }
+  asset SubBravo extends Bravo {
+  }
+  asset SubSubBravo extends SubBravo {
+  }
+}
+
+associations {
+  Alpha [alphas] * <-- _ --> * [bravos] Bravo
+  Bravo [subbravos] * <-- _ --> * [parentbravos] Bravo
+}


### PR DESCRIPTION
Previously `.subIPRanges*[PublicIpRange]` was not allowed without parenthesis, now it is. Also allows for some more valid (but obscure) syntax.