### PR TITLE
Update to our forked javapoet version 1.13.0-SNAPSHOT

### DIFF
--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/JavaGenerator.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/JavaGenerator.java
@@ -24,6 +24,7 @@ import com.squareup.javapoet.TypeSpec;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.SourceVersion;
@@ -43,6 +44,7 @@ import org.mal_lang.compiler.lib.Lang.StepUnion;
 public abstract class JavaGenerator extends Generator {
 
   protected String pkg;
+  protected String[] alwaysQualifiedNames;
 
   protected JavaGenerator(boolean verbose, boolean debug) {
     this(verbose, debug, "");
@@ -309,6 +311,20 @@ public abstract class JavaGenerator extends Generator {
     }
     if (err) {
       throw error();
+    }
+  }
+
+  protected void fillAlwaysQualifiedNames(Lang lang) {
+    var alwaysQualifiedNames = new LinkedHashSet<String>();
+    for (var asset : lang.getAssets().values()) {
+      for (var attackStepName : asset.getAttackSteps().keySet()) {
+        alwaysQualifiedNames.add(ucFirst(attackStepName));
+      }
+    }
+    this.alwaysQualifiedNames = new String[alwaysQualifiedNames.size()];
+    var iterator = alwaysQualifiedNames.iterator();
+    for (int i = 0; i < alwaysQualifiedNames.size(); i++) {
+      this.alwaysQualifiedNames[i] = iterator.next();
     }
   }
 

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/reference/Generator.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/reference/Generator.java
@@ -94,18 +94,13 @@ public class Generator extends JavaGenerator {
 
     validateNames(this.lang);
     checkSteps(this.lang);
+    fillAlwaysQualifiedNames(this.lang);
   }
 
   private void _generate() throws IOException, CompilerException {
     for (Asset asset : lang.getAssets().values()) {
-      var javaFile = JavaFile.builder(pkg, createAsset(asset));
-      for (var a : lang.getAssets().values()) {
-        for (var b : a.getAttackSteps().values()) {
-          javaFile.alwaysQualify(ucFirst(b.getName()));
-        }
-      }
-      javaFile.skipJavaLangImports(true);
-      javaFile.build().writeTo(this.output);
+      var javaFile = JavaFile.builder(pkg, createAsset(asset)).build();
+      javaFile.writeTo(this.output);
     }
     if (core) {
       _generateCore();
@@ -211,6 +206,7 @@ public class Generator extends JavaGenerator {
   private TypeSpec createAsset(Asset asset) {
     LOGGER.info(String.format("Creating '%s.java'", asset.getName()));
     TypeSpec.Builder builder = TypeSpec.classBuilder(asset.getName());
+    builder.alwaysQualify(this.alwaysQualifiedNames);
     builder.addModifiers(Modifier.PUBLIC);
     if (asset.isAbstract()) {
       builder.addModifiers(Modifier.ABSTRACT);

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/AssetGenerator.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/AssetGenerator.java
@@ -53,12 +53,20 @@ public class AssetGenerator extends JavaGenerator {
   private final AttackStepGenerator asGen;
   private final DefenseGenerator defGen;
   private final VariableGenerator varGen;
+  private final String[] alwaysQualifiedNames;
 
-  protected AssetGenerator(MalLogger LOGGER, String pkg, File output, File icons, Lang lang) {
+  protected AssetGenerator(
+      MalLogger LOGGER,
+      String pkg,
+      File output,
+      File icons,
+      Lang lang,
+      String[] alwaysQualifiedNames) {
     super(LOGGER, pkg);
     this.output = output;
     this.icons = icons;
     this.lang = lang;
+    this.alwaysQualifiedNames = alwaysQualifiedNames;
     asGen = new AttackStepGenerator(LOGGER, pkg);
     defGen = new DefenseGenerator(LOGGER, pkg);
     varGen = new VariableGenerator(LOGGER, pkg);
@@ -67,6 +75,7 @@ public class AssetGenerator extends JavaGenerator {
   protected void generate(Asset asset) throws IOException {
     LOGGER.info(String.format("Creating '%s.java'", asset.getName()));
     TypeSpec.Builder builder = TypeSpec.classBuilder(asset.getName());
+    builder.alwaysQualify(this.alwaysQualifiedNames);
 
     // @annotations
     createAssetAnnotations(builder, asset);
@@ -143,14 +152,8 @@ public class AssetGenerator extends JavaGenerator {
       createClearCache(builder, asset, variables);
     }
 
-    var file = JavaFile.builder(this.pkg, builder.build());
-    for (var a : lang.getAssets().values()) {
-      for (var b : a.getAttackSteps().values()) {
-        file.alwaysQualify(ucFirst(b.getName()));
-      }
-    }
-    file.skipJavaLangImports(true);
-    file.build().writeTo(this.output);
+    var file = JavaFile.builder(this.pkg, builder.build()).build();
+    file.writeTo(this.output);
   }
 
   private void createClearCache(

--- a/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/Generator.java
+++ b/malcompiler-lib/src/main/java/org/mal_lang/compiler/lib/securicad/Generator.java
@@ -107,6 +107,7 @@ public class Generator extends JavaGenerator {
     removeDebugSteps(this.lang);
     validateNames(this.lang);
     checkSteps(this.lang);
+    fillAlwaysQualifiedNames(this.lang);
   }
 
   private static Lang.AttackStep getTargetStep(Lang.StepExpr expr) {
@@ -166,7 +167,7 @@ public class Generator extends JavaGenerator {
   }
 
   private void _generate() throws IOException, CompilerException {
-    AssetGenerator ag = new AssetGenerator(LOGGER, pkg, output, icons, lang);
+    AssetGenerator ag = new AssetGenerator(LOGGER, pkg, output, icons, lang, alwaysQualifiedNames);
     for (Asset asset : lang.getAssets().values()) {
       ag.generate(asset);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@ limitations under the License.
       <dependency>
         <groupId>org.mal-lang</groupId>
         <artifactId>javapoet</artifactId>
-        <version>1.12.0-SNAPSHOT</version>
+        <version>1.13.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>guru.nidi.com.kitfox</groupId>


### PR DESCRIPTION
JavaPoet has merged the alwaysQualify() API, so our forked JavaPoet version 1.13.0-SNAPSHOT is now based on upstream version 1.12.1.